### PR TITLE
Determine product automatically for selecting SCAP guide

### DIFF
--- a/org_fedora_oscap/common.py
+++ b/org_fedora_oscap/common.py
@@ -36,6 +36,7 @@ from functools import wraps
 
 from pyanaconda import constants
 from pyanaconda import nm
+from pyanaconda.constants import product
 from pyanaconda.threads import threadMgr, AnacondaThread
 
 from org_fedora_oscap import utils
@@ -50,6 +51,9 @@ TARGET_CONTENT_DIR = "/root/openscap_data/"
 
 SSG_DIR = "/usr/share/xml/scap/ssg/fedora/"
 SSG_XCCDF = "ssg-fedora-xccdf.xml"
+if product.productName.lower() != 'anaconda':
+    if product.productName.lower() != 'fedora':
+        SSG_XCCDF = "ssg-%s%s-xccdf.xml" %(product.productName.lower(), product.productVersion)
 
 RESULTS_PATH = utils.join_paths(TARGET_CONTENT_DIR, "eval_remediate_results.xml")
 


### PR DESCRIPTION
Using anaconda's knowledge of what product and version this is we can dynamically select a more intelligent default SCAP guide.  This patch eliminates the need to customize the search location for RHEL (and other rebuilds).