### PR TITLE
Update oscap-anaconda-addon.spec

### DIFF
--- a/oscap-anaconda-addon.spec
+++ b/oscap-anaconda-addon.spec
@@ -1,17 +1,17 @@
 Name:           oscap-anaconda-addon
 Version:        0.7
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Anaconda addon integrating OpenSCAP to the installation process
 
 License:        GPLv2+
-URL:            https://git.fedorahosted.org/cgit/oscap-anaconda-addon.git
+URL:            https://github.com/OpenSCAP/oscap-anaconda-addon.git
 
 # This is a Red Hat maintained package which is specific to
 # our distribution.
 #
 # The source is thus available only from within this SRPM
 # or via direct git checkout:
-# git clone git://git.fedorahosted.org/oscap-anaconda-addon.git
+# git clone https://github.com/OpenSCAP/oscap-anaconda-addon.git
 Source0:        %{name}-%{version}.tar.gz
 
 BuildArch:      noarch
@@ -51,6 +51,9 @@ make install DESTDIR=%{buildroot}
 %doc COPYING ChangeLog README
 
 %changelog
+* Mon Feb 13 2017 Jiri Konecny <jkonecny@redhat.com> - 0.7-2
+- Fix URL which is now poiting to GitHub instead of fedorahosted
+
 * Wed Jan 07 2015 Vratislav Podzimek <vpodzime@redhat.com> - 0.7-1
 - Adapt to changes in Anaconda
 - Add *~ to EXCLUDES (#1081735)


### PR DESCRIPTION
It is no longer hosted on fedorahosted so fix the link.