### PR TITLE
Use the init_done signal instead of wait_all() (#1380224)

### DIFF
--- a/oscap-anaconda-addon.spec
+++ b/oscap-anaconda-addon.spec
@@ -21,8 +21,8 @@ BuildRequires:  python-mock
 BuildRequires:  python-nose
 BuildRequires:  openscap openscap-utils openscap-python
 BuildRequires:  python-cpio
-BuildRequires:  anaconda >= 21.35
-Requires:       anaconda >= 21.35
+BuildRequires:  anaconda >= 21.48.22.99
+Requires:       anaconda >= 21.48.22.99
 Requires:       openscap openscap-utils openscap-python
 Requires:       python-cpio
 


### PR DESCRIPTION
Using the wait_all() function provided by the Anaconda thread manager
singleton can result in unexpected behavior, as there migh still be
threads unrelated to spoke initialization still running when the
function is called. This might result in unnecessary delay before the
OSCAP addon spoke becomes ready and installation can continue.

So use the init_done signal, which is the proper way to wait for
Anaconda spokes to finish initialization.

Also bump the Anaconda version to one that provides the init_done
signal.

Resolves: rhbz#1380224