### PR TITLE
Gtk: Fix gtk warning (#1437106)

### DIFF
--- a/org_fedora_oscap/gui/spokes/oscap.glade
+++ b/org_fedora_oscap/gui/spokes/oscap.glade
@@ -406,20 +406,6 @@
                       </packing>
                     </child>
                     <child>
-                      <placeholder/>
-                    </child>
-                    <child type="tab">
-                      <object class="GtkLabel" id="label2">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label">Fetch Content</property>
-                      </object>
-                      <packing>
-                        <property name="position">1</property>
-                        <property name="tab_fill">False</property>
-                      </packing>
-                    </child>
-                    <child>
                       <object class="GtkBox" id="contentUrlBox">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
@@ -554,7 +540,18 @@
                         </child>
                       </object>
                       <packing>
-                        <property name="position">2</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child type="tab">
+                      <object class="GtkLabel" id="label2">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label">Fetch Content</property>
+                      </object>
+                      <packing>
+                        <property name="position">1</property>
+                        <property name="tab_fill">False</property>
                       </packing>
                     </child>
                   </object>

--- a/org_fedora_oscap/gui/spokes/oscap.glade
+++ b/org_fedora_oscap/gui/spokes/oscap.glade
@@ -46,7 +46,6 @@
         <property name="spacing">6</property>
         <child internal-child="nav_box">
           <object class="GtkEventBox" id="AnacondaSpokeWindow-nav_box1">
-            <property name="app_paintable">True</property>
             <property name="can_focus">False</property>
             <child internal-child="nav_area">
               <object class="GtkGrid" id="AnacondaSpokeWindow-nav_area1">


### PR DESCRIPTION
The warning "Overriding tab label for notebook" was caused by an empty page in the notebook. The page was removed.

The app_paintable property suppressed drawing of the upper bar's background. The property was removed.

Resolves: rhbz#1437106