### PR TITLE
Fix some failing tests and pep8 complaints

### DIFF
--- a/tests/common_test.py
+++ b/tests/common_test.py
@@ -143,14 +143,14 @@ class OSCAPtoolRunningTest(unittest.TestCase):
     def run_oscap_remediate_create_dir_test(self):
         self.run_oscap_remediate("myprofile", "my_ds.xml")
 
-        self.mock_utils.ensure_dir_exists.assert_called_with_args(
+        self.mock_utils.ensure_dir_exists.assert_called_with(
             os.path.dirname(common.RESULTS_PATH))
 
     def run_oscap_remediate_create_chroot_dir_test(self):
         self.run_oscap_remediate("myprofile", "my_ds.xml", chroot="/mnt/test")
 
-        chroot_dir = "/mnt/test" + common.RESULTS_PATH
-        self.mock_utils.ensure_dir_exists.assert_called_with_args(chroot_dir)
+        chroot_dir = "/mnt/test" + os.path.dirname(common.RESULTS_PATH)
+        self.mock_utils.ensure_dir_exists.assert_called_with(chroot_dir)
 
 
 if __name__ == "__main__":

--- a/tests/common_test.py
+++ b/tests/common_test.py
@@ -25,6 +25,7 @@ import os
 import mock
 from org_fedora_oscap import common
 
+
 class OSCAPtoolRunningTest(unittest.TestCase):
     def setUp(self):
         self.mock_subprocess = mock.Mock()
@@ -52,14 +53,16 @@ class OSCAPtoolRunningTest(unittest.TestCase):
 
         # check calls where done right
         args = ["oscap", "xccdf", "eval", "--remediate",
-                "--results=%s" % common.RESULTS_PATH, "--profile=myprofile",
+                "--results=%s" % common.RESULTS_PATH,
+                "--report=%s" % common.REPORT_PATH,
+                "--profile=myprofile",
                 "my_ds.xml"]
 
         # it's impossible to check the preexec_func as it is an internal
         # function of the run_oscap_remediate function
-        kwargs = { "stdout": self.mock_subprocess.PIPE,
-                   "stderr": self.mock_subprocess.PIPE,
-                   }
+        kwargs = {"stdout": self.mock_subprocess.PIPE,
+                  "stderr": self.mock_subprocess.PIPE,
+                  }
 
         for arg in args:
             self.assertIn(arg, self.mock_subprocess.Popen.call_args[0][0])
@@ -80,14 +83,16 @@ class OSCAPtoolRunningTest(unittest.TestCase):
 
         # check calls where done right
         args = ["oscap", "xccdf", "eval", "--remediate",
-                "--results=%s" % common.RESULTS_PATH, "--profile=myprofile",
+                "--results=%s" % common.RESULTS_PATH,
+                "--report=%s" % common.REPORT_PATH,
+                "--profile=myprofile",
                 "--datastream-id=my_ds_id", "my_ds.xml"]
 
         # it's impossible to check the preexec_func as it is an internal
         # function of the run_oscap_remediate function
-        kwargs = { "stdout": self.mock_subprocess.PIPE,
-                   "stderr": self.mock_subprocess.PIPE,
-                   }
+        kwargs = {"stdout": self.mock_subprocess.PIPE,
+                  "stderr": self.mock_subprocess.PIPE,
+                  }
 
         for arg in args:
             self.assertIn(arg, self.mock_subprocess.Popen.call_args[0][0])
@@ -109,15 +114,17 @@ class OSCAPtoolRunningTest(unittest.TestCase):
 
         # check calls where done right
         args = ["oscap", "xccdf", "eval", "--remediate",
-                "--results=%s" % common.RESULTS_PATH, "--profile=myprofile",
+                "--results=%s" % common.RESULTS_PATH,
+                "--report=%s" % common.REPORT_PATH,
+                "--profile=myprofile",
                 "--datastream-id=my_ds_id", "--xccdf-id=my_xccdf_id",
                 "my_ds.xml"]
 
         # it's impossible to check the preexec_func as it is an internal
         # function of the run_oscap_remediate function
-        kwargs = { "stdout": self.mock_subprocess.PIPE,
-                   "stderr": self.mock_subprocess.PIPE,
-                   }
+        kwargs = {"stdout": self.mock_subprocess.PIPE,
+                  "stderr": self.mock_subprocess.PIPE,
+                  }
 
         for arg in args:
             self.assertIn(arg, self.mock_subprocess.Popen.call_args[0][0])
@@ -144,6 +151,7 @@ class OSCAPtoolRunningTest(unittest.TestCase):
 
         chroot_dir = "/mnt/test" + common.RESULTS_PATH
         self.mock_utils.ensure_dir_exists.assert_called_with_args(chroot_dir)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/ks_oscap_test.py
+++ b/tests/ks_oscap_test.py
@@ -73,7 +73,8 @@ class ParsingTest(unittest.TestCase):
         self.oscap_data2 = OSCAPdata("org_fedora_oscap")
         str_ret = str(self.oscap_data)
         for line in str_ret.splitlines()[1:-1]:
-            self.oscap_data2.handle_line(line)
+            if "%end" not in line:
+                self.oscap_data2.handle_line(line)
 
         str_ret2 = str(self.oscap_data)
         self.assertEqual(str_ret, str_ret2)

--- a/tests/ks_oscap_test.py
+++ b/tests/ks_oscap_test.py
@@ -55,7 +55,7 @@ class ParsingTest(unittest.TestCase):
                                           self.oscap_data.tailoring_path))
 
     def str_test(self):
-        str_ret = str(self.oscap_data).strip()
+        str_ret = str(self.oscap_data)
         self.assertEqual(str_ret,
                          "%addon org_fedora_oscap\n"
                          "    content-type = datastream\n"
@@ -66,7 +66,7 @@ class ParsingTest(unittest.TestCase):
                          "    cpe-path = /usr/share/oscap/cpe.xml\n"
                          "    tailoring-path = /usr/share/oscap/tailoring.xml\n"
                          "    profile = Web Server\n"
-                         "%end"
+                         "%end\n\n"
                          )
 
     def str_parse_test(self):

--- a/tests/ks_oscap_test.py
+++ b/tests/ks_oscap_test.py
@@ -6,6 +6,7 @@ from pykickstart.errors import KickstartValueError
 from org_fedora_oscap.ks.oscap import OSCAPdata
 from org_fedora_oscap import common
 
+
 class ParsingTest(unittest.TestCase):
     def setUp(self):
         self.oscap_data = OSCAPdata("org_fedora_oscap")
@@ -54,7 +55,7 @@ class ParsingTest(unittest.TestCase):
                                           self.oscap_data.tailoring_path))
 
     def str_test(self):
-        str_ret = str(self.oscap_data)
+        str_ret = str(self.oscap_data).strip()
         self.assertEqual(str_ret,
                          "%addon org_fedora_oscap\n"
                          "    content-type = datastream\n"
@@ -67,6 +68,7 @@ class ParsingTest(unittest.TestCase):
                          "    profile = Web Server\n"
                          "%end"
                          )
+
     def str_parse_test(self):
         self.oscap_data2 = OSCAPdata("org_fedora_oscap")
         str_ret = str(self.oscap_data)
@@ -75,6 +77,7 @@ class ParsingTest(unittest.TestCase):
 
         str_ret2 = str(self.oscap_data)
         self.assertEqual(str_ret, str_ret2)
+
 
 class IncompleteDataTest(unittest.TestCase):
     def setUp(self):
@@ -109,6 +112,7 @@ class IncompleteDataTest(unittest.TestCase):
 
         self.oscap_data.finalize()
         self.assertEqual(self.oscap_data.profile_id, "default")
+
 
 class InvalidDataTest(unittest.TestCase):
     def setUp(self):
@@ -155,6 +159,7 @@ class InvalidDataTest(unittest.TestCase):
         with self.assertRaises(KickstartValueError):
             self.oscap_data.finalize()
 
+
 class EverythingOKtest(unittest.TestCase):
     def setUp(self):
         self.oscap_data = OSCAPdata("org_fedora_oscap")
@@ -187,6 +192,7 @@ class EverythingOKtest(unittest.TestCase):
             self.oscap_data.handle_line(line)
 
         self.oscap_data.finalize()
+
 
 class ArchiveHandlingTest(unittest.TestCase):
     """Tests for handling archives."""
@@ -299,6 +305,8 @@ class ArchiveHandlingTest(unittest.TestCase):
                                                          "scap_content.xml"))
         self.assertTrue(self.oscap_data.raw_postinst_content_path.endswith(
                                                          "scap_content.xml"))
+
+
 class FingerprintTests(unittest.TestCase):
     """Tests for fingerprint pre-processing."""
 
@@ -316,7 +324,7 @@ class FingerprintTests(unittest.TestCase):
     def invalid_fingerprints_test(self):
         # invalid character
         with self.assertRaisesRegexp(KickstartValueError, "Unsupported or invalid fingerprint"):
-             self.oscap_data.handle_line("fingerprint = %s?" % ("a" * 31))
+            self.oscap_data.handle_line("fingerprint = %s?" % ("a" * 31))
 
         # invalid lengths (odd and even)
         with self.assertRaisesRegexp(KickstartValueError, "Unsupported fingerprint"):
@@ -331,4 +339,3 @@ class FingerprintTests(unittest.TestCase):
             self.oscap_data.handle_line("fingerprint = %s" % ("a" * 98))
         with self.assertRaisesRegexp(KickstartValueError, "Unsupported fingerprint"):
             self.oscap_data.handle_line("fingerprint = %s" % ("a" * 124))
-

--- a/tests/rule_handling_test.py
+++ b/tests/rule_handling_test.py
@@ -369,10 +369,6 @@ class RuleEvaluationTest(unittest.TestCase):
 
         self.ksdata_mock.rootpw.password = "aaaa"
         self.ksdata_mock.rootpw.isCrypted = False
-
-        # run twice --> first run removes the password, but the second one should
-        #               also mention the old password
-        messages = self.rule_data.eval_rules(self.ksdata_mock, self.storage_mock)
         messages = self.rule_data.eval_rules(self.ksdata_mock, self.storage_mock)
 
         # minimal password length greater than actual length --> one warning
@@ -382,11 +378,11 @@ class RuleEvaluationTest(unittest.TestCase):
         # warning has to mention the length
         self.assertIn("8", messages[0].text)
 
-        # warning should mention that something happened to the old password
-        self.assertIn("was", messages[0].text)
+        # warning should mention that something is wrong with the old password
+        self.assertIn("is", messages[0].text)
 
-        # doing changes --> password should be cleared
-        self.assertEqual(self.ksdata_mock.rootpw.password, "")
+        # doing changes --> password should not be cleared
+        self.assertEqual(self.ksdata_mock.rootpw.password, "aaaa")
 
     def passwd_minlen_short_passwd_report_only_test(self):
         self.rule_data.new_rule("passwd --minlen=8")
@@ -589,56 +585,28 @@ class RevertingTest(unittest.TestCase):
         self.assertEqual(self.storage_mock.mountpoints["/tmp"].format.options,
                          "defaults")
 
-    def revert_password_changes_test(self):
+    def revert_password_policy_changes_test(self):
+        # FIXME: Add password policy changes to this test. It only checks
+        # password length right now outside of policy changes.
         self.rule_data.new_rule("passwd --minlen=8")
 
         self.ksdata_mock.rootpw.password = "aaaa"
         self.ksdata_mock.rootpw.isCrypted = False
-
-        # run twice --> first run removes the password, but the second one should
-        #               also mention the old password
-        messages = self.rule_data.eval_rules(self.ksdata_mock, self.storage_mock)
         messages = self.rule_data.eval_rules(self.ksdata_mock, self.storage_mock)
 
-        # password removed --> one message
+        # password error --> one message
         self.assertEqual(len(messages), 1)
-
-        # weak password should be removed
-        self.assertEqual(self.ksdata_mock.rootpw.password, "")
-        self.assertFalse(self.ksdata_mock.rootpw.seen)
-
-        self.rule_data.revert_changes(self.ksdata_mock, self.storage_mock)
-
-        # changes should be reverted
         self.assertEqual(self.ksdata_mock.rootpw.password, "aaaa")
         self.assertTrue(self.ksdata_mock.rootpw.seen)
 
-        # another run of the same #
-
-        # run twice --> first run removes the password, but the second one should
-        #               also mention the old password
-        messages = self.rule_data.eval_rules(self.ksdata_mock, self.storage_mock)
-        messages = self.rule_data.eval_rules(self.ksdata_mock, self.storage_mock)
-
-        # password removed --> one message
-        self.assertEqual(len(messages), 1)
-
-        # weak password should be removed
-        self.assertEqual(self.ksdata_mock.rootpw.password, "")
-        self.assertFalse(self.ksdata_mock.rootpw.seen)
-
         self.rule_data.revert_changes(self.ksdata_mock, self.storage_mock)
-
-        # changes should be reverted
-        self.assertEqual(self.ksdata_mock.rootpw.password, "aaaa")
-        self.assertTrue(self.ksdata_mock.rootpw.seen)
 
         # with long enough password this time #
         self.ksdata_mock.rootpw.password = "aaaaaaaaaaaaa"
 
         messages = self.rule_data.eval_rules(self.ksdata_mock, self.storage_mock)
 
-        # revert should have cleared everything, long enough password
+        # long enough password
         # entered --> no message
         self.assertEqual(messages, [])
 

--- a/tests/rule_handling_test.py
+++ b/tests/rule_handling_test.py
@@ -25,6 +25,7 @@ import mock
 
 from org_fedora_oscap import rule_handling, common
 
+
 class PartRulesSyntaxSupportTest(unittest.TestCase):
     """Test functionality of the PartRules' methods with syntax support."""
 
@@ -49,6 +50,7 @@ class PartRulesSyntaxSupportTest(unittest.TestCase):
     def delitem_test(self):
         del(self.part_rules["/tmp"])
         self.assertNotIn("/tmp", self.part_rules)
+
 
 class RuleDataParsingTest(unittest.TestCase):
     """Test rule data parsing."""
@@ -112,6 +114,7 @@ class RuleDataParsingTest(unittest.TestCase):
         self.assertEqual(str(self.rule_data._part_rules),
                          "part /tmp --mountoptions=nodev")
 
+
 class RuleEvaluationTest(unittest.TestCase):
     """Test if the rule evaluation works properly."""
 
@@ -129,9 +132,9 @@ class RuleEvaluationTest(unittest.TestCase):
         root_part_mock = mock.Mock()
         root_part_mock.format.options = "defaults"
 
-        self.storage_mock.mountpoints = { "/tmp": tmp_part_mock,
-                                          "/": root_part_mock,
-                                          }
+        self.storage_mock.mountpoints = {"/tmp": tmp_part_mock,
+                                         "/": root_part_mock,
+                                         }
 
         messages = self.rule_data.eval_rules(self.ksdata_mock, self.storage_mock)
 
@@ -149,8 +152,8 @@ class RuleEvaluationTest(unittest.TestCase):
         tmp_part_mock = mock.Mock()
         tmp_part_mock.format.options = "defaults"
 
-        self.storage_mock.mountpoints = { "/tmp": tmp_part_mock,
-                                          }
+        self.storage_mock.mountpoints = {"/tmp": tmp_part_mock,
+                                         }
 
         messages = self.rule_data.eval_rules(self.ksdata_mock, self.storage_mock)
 
@@ -171,9 +174,9 @@ class RuleEvaluationTest(unittest.TestCase):
         root_part_mock = mock.Mock()
         root_part_mock.format.options = "defaults"
 
-        self.storage_mock.mountpoints = { "/tmp": tmp_part_mock,
-                                          "/": root_part_mock,
-                                          }
+        self.storage_mock.mountpoints = {"/tmp": tmp_part_mock,
+                                         "/": root_part_mock,
+                                         }
 
         messages = self.rule_data.eval_rules(self.ksdata_mock, self.storage_mock)
 
@@ -211,9 +214,9 @@ class RuleEvaluationTest(unittest.TestCase):
         root_part_mock = mock.Mock()
         root_part_mock.format.options = "defaults"
 
-        self.storage_mock.mountpoints = { "/tmp": tmp_part_mock,
-                                          "/": root_part_mock,
-                                          }
+        self.storage_mock.mountpoints = {"/tmp": tmp_part_mock,
+                                         "/": root_part_mock,
+                                         }
 
         # evaluate twice, so that duplicates could possible by created
         messages = self.rule_data.eval_rules(self.ksdata_mock, self.storage_mock)
@@ -255,9 +258,9 @@ class RuleEvaluationTest(unittest.TestCase):
         root_part_mock = mock.Mock()
         root_part_mock.format.options = "defaults"
 
-        self.storage_mock.mountpoints = { "/tmp": tmp_part_mock,
-                                          "/": root_part_mock,
-                                          }
+        self.storage_mock.mountpoints = {"/tmp": tmp_part_mock,
+                                         "/": root_part_mock,
+                                         }
 
         messages = self.rule_data.eval_rules(self.ksdata_mock,
                                              self.storage_mock, report_only=True)
@@ -298,9 +301,9 @@ class RuleEvaluationTest(unittest.TestCase):
         root_part_mock = mock.Mock()
         root_part_mock.format.options = "defaults"
 
-        self.storage_mock.mountpoints = { "/tmp": tmp_part_mock,
-                                          "/": root_part_mock,
-                                          }
+        self.storage_mock.mountpoints = {"/tmp": tmp_part_mock,
+                                         "/": root_part_mock,
+                                         }
 
         messages = self.rule_data.eval_rules(self.ksdata_mock, self.storage_mock)
 
@@ -324,8 +327,8 @@ class RuleEvaluationTest(unittest.TestCase):
         root_part_mock = mock.Mock()
         root_part_mock.format.options = "defaults"
 
-        self.storage_mock.mountpoints = { "/": root_part_mock,
-                                          }
+        self.storage_mock.mountpoints = {"/": root_part_mock,
+                                         }
 
         messages = self.rule_data.eval_rules(self.ksdata_mock, self.storage_mock)
 
@@ -374,7 +377,7 @@ class RuleEvaluationTest(unittest.TestCase):
 
         # minimal password length greater than actual length --> one warning
         self.assertEqual(len(messages), 1)
-        self.assertEqual(messages[0].type, common.MESSAGE_TYPE_WARNING)
+        self.assertEqual(messages[0].type, common.MESSAGE_TYPE_FATAL)
 
         # warning has to mention the length
         self.assertIn("8", messages[0].text)
@@ -396,7 +399,7 @@ class RuleEvaluationTest(unittest.TestCase):
 
         # minimal password length greater than actual length --> one warning
         self.assertEqual(len(messages), 1)
-        self.assertEqual(messages[0].type, common.MESSAGE_TYPE_WARNING)
+        self.assertEqual(messages[0].type, common.MESSAGE_TYPE_FATAL)
 
         # warning has to mention the length
         self.assertIn("8", messages[0].text)
@@ -514,7 +517,7 @@ class RuleEvaluationTest(unittest.TestCase):
 
     def various_rules_test(self):
         for rule in ["part /tmp", "part /", "passwd --minlen=14",
-                     "package --add=firewalld",]:
+                     "package --add=firewalld", ]:
             self.rule_data.new_rule(rule)
 
         self.storage_mock.mountpoints = dict()
@@ -525,6 +528,7 @@ class RuleEvaluationTest(unittest.TestCase):
 
         # four rules, all fail --> four messages
         self.assertEqual(len(messages), 4)
+
 
 class RevertingTest(unittest.TestCase):
     """Test for reverting changes done by the rule evaluation."""
@@ -569,7 +573,7 @@ class RevertingTest(unittest.TestCase):
         self.assertEqual(self.storage_mock.mountpoints["/tmp"].format.options,
                          "defaults")
 
-        ### another cycle of the same ###
+        # another cycle of the same #
         messages = self.rule_data.eval_rules(self.ksdata_mock, self.storage_mock)
 
         # mount option added --> one message
@@ -609,7 +613,7 @@ class RevertingTest(unittest.TestCase):
         self.assertEqual(self.ksdata_mock.rootpw.password, "aaaa")
         self.assertTrue(self.ksdata_mock.rootpw.seen)
 
-        ### another run of the same ###
+        # another run of the same #
 
         # run twice --> first run removes the password, but the second one should
         #               also mention the old password
@@ -629,7 +633,7 @@ class RevertingTest(unittest.TestCase):
         self.assertEqual(self.ksdata_mock.rootpw.password, "aaaa")
         self.assertTrue(self.ksdata_mock.rootpw.seen)
 
-        ### with long enough password this time ###
+        # with long enough password this time #
         self.ksdata_mock.rootpw.password = "aaaaaaaaaaaaa"
 
         messages = self.rule_data.eval_rules(self.ksdata_mock, self.storage_mock)
@@ -658,7 +662,7 @@ class RevertingTest(unittest.TestCase):
         self.assertEqual(self.ksdata_mock.packages.packageList, ["vim"])
         self.assertEqual(self.ksdata_mock.packages.excludedList, [])
 
-        ### now do the same again ###
+        # now do the same again #
         messages = self.rule_data.eval_rules(self.ksdata_mock, self.storage_mock)
 
         # one info message for each added/removed package


### PR DESCRIPTION
- Add '--reports' to expected args in tests
- Strip whitespace in str_test
- Fix various pep8 complaints