### PR TITLE
Update Makefile to handle python2 and python3 tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,13 @@ VERSION = 0.7
 ADDON = org_fedora_oscap
 TESTS = tests
 
+OSVERSION := $(shell grep -o " [0-9]\{1,\}" /etc/redhat-release | sed "s/ //g")
+ifeq ($(OSVERSION),7)
+	PYVERSION = ""
+else
+	PYVERSION = -3
+endif
+
 FILES = $(ADDON) \
 	$(TESTS) \
 	po \
@@ -76,15 +83,15 @@ install-po-files:
 	$(MAKE) -C po install
 
 test:
-	@echo "***Running pylint checks***"
-	@find . -name '*.py' -print|xargs -n1 --max-procs=$(NUM_PROCS) pylint -E 2> /dev/null
+	@echo "***Running pylint$(PYVERSION) checks***"
+	@find . -name '*.py' -print|xargs -n1 --max-procs=$(NUM_PROCS) pylint$(PYVERSION) -E 2> /dev/null
 	@echo "[ OK ]"
 	@echo "***Running unittests checks***"
-	@PYTHONPATH=. nosetests --processes=-1 -vw tests/
+	@PYTHONPATH=. nosetests$(PYVERSION) --processes=-1 -vw tests/
 
 runpylint:
-	@find . -name '*.py' -print|xargs -n1 --max-procs=$(NUM_PROCS) pylint -E 2> /dev/null
+	@find . -name '*.py' -print|xargs -n1 --max-procs=$(NUM_PROCS) pylint$(PYVERSION) -E 2> /dev/null
 	@echo "[ OK ]"
 
 unittest:
-	PYTHONPATH=. nosetests --processes=-1 -vw tests/
+	PYTHONPATH=. nosetests$(PYVERSION) --processes=-1 -vw tests/


### PR DESCRIPTION
- Makefile checks if OS is Red Hat Enterprise Linux 7 for python2 tests. If not, uses python3 tests