### PR TITLE
When using content from SSG, use the DataStream by default

### DIFF
--- a/org_fedora_oscap/common.py
+++ b/org_fedora_oscap/common.py
@@ -52,12 +52,12 @@ INSTALLATION_CONTENT_DIR = "/tmp/openscap_data/"
 TARGET_CONTENT_DIR = "/root/openscap_data/"
 
 SSG_DIR = "/usr/share/xml/scap/ssg/content/"
-SSG_XCCDF = "ssg-rhel7-xccdf.xml"
+SSG_SDS = "ssg-rhel7-ds.xml"
 if constants.shortProductName != 'anaconda':
     if constants.shortProductName == 'fedora':
-        SSG_XCCDF = "ssg-fedora-xccdf.xml"
+        SSG_SDS  = "ssg-fedora-ds.xml"
     else:
-        SSG_XCCDF = "ssg-%s%s-xccdf.xml" % (constants.shortProductName,
+        SSG_SDS = "ssg-%s%s-ds.xml" % (constants.shortProductName,
                                             constants.productVersion.strip(".")[0])
 
 RESULTS_PATH = utils.join_paths(TARGET_CONTENT_DIR,
@@ -494,7 +494,7 @@ def ssg_available(root="/"):
 
     """
 
-    return os.path.exists(utils.join_paths(root, SSG_DIR + SSG_XCCDF))
+    return os.path.exists(utils.join_paths(root, SSG_DIR + SSG_SDS))
 
 
 def dry_run_skip(func):

--- a/org_fedora_oscap/common.py
+++ b/org_fedora_oscap/common.py
@@ -52,12 +52,12 @@ INSTALLATION_CONTENT_DIR = "/tmp/openscap_data/"
 TARGET_CONTENT_DIR = "/root/openscap_data/"
 
 SSG_DIR = "/usr/share/xml/scap/ssg/content/"
-SSG_SDS = "ssg-rhel7-ds.xml"
+SSG_CONTENT = "ssg-rhel7-ds.xml"
 if constants.shortProductName != 'anaconda':
     if constants.shortProductName == 'fedora':
-        SSG_SDS  = "ssg-fedora-ds.xml"
+        SSG_CONTENT  = "ssg-fedora-ds.xml"
     else:
-        SSG_SDS = "ssg-%s%s-ds.xml" % (constants.shortProductName,
+        SSG_CONTENT = "ssg-%s%s-ds.xml" % (constants.shortProductName,
                                             constants.productVersion.strip(".")[0])
 
 RESULTS_PATH = utils.join_paths(TARGET_CONTENT_DIR,
@@ -494,7 +494,7 @@ def ssg_available(root="/"):
 
     """
 
-    return os.path.exists(utils.join_paths(root, SSG_DIR + SSG_SDS))
+    return os.path.exists(utils.join_paths(root, SSG_DIR + SSG_CONTENT))
 
 
 def dry_run_skip(func):

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -284,7 +284,7 @@ class OSCAPSpoke(NormalSpoke):
         # if no content was specified and SSG is available, use it
         if not self._addon_data.content_type and common.ssg_available():
             self._addon_data.content_type = "scap-security-guide"
-            self._addon_data.xccdf_path = common.SSG_DIR + common.SSG_SDS
+            self._addon_data.content_path = common.SSG_DIR + common.SSG_SDS
 
         if not self._addon_data.content_defined:
             # nothing more to be done now, the spoke is ready
@@ -386,7 +386,7 @@ class OSCAPSpoke(NormalSpoke):
             try:
                 fpaths = common.extract_data(self._addon_data.raw_preinst_content_path,
                                              common.INSTALLATION_CONTENT_DIR,
-                                             [self._addon_data.xccdf_path])
+                                             [self._addon_data.content_path])
             except common.ExtractionError as err:
                 self._extraction_failed(err.message)
                 # fetching done
@@ -399,7 +399,7 @@ class OSCAPSpoke(NormalSpoke):
             files = common.strip_content_dir(files)
 
             # pylint: disable-msg=E1103
-            self._addon_data.xccdf_path = self._addon_data.xccdf_path or files.xccdf
+            self._addon_data.content_path = self._addon_data.content_path or files.xccdf
             self._addon_data.cpe_path = self._addon_data.cpe_path or files.cpe
             self._addon_data.tailoring_path = (self._addon_data.tailoring_path or
                                                files.tailoring)
@@ -1130,5 +1130,5 @@ class OSCAPSpoke(NormalSpoke):
     def on_use_ssg_clicked(self, *args):
         self._addon_data.clear_all()
         self._addon_data.content_type = "scap-security-guide"
-        self._addon_data.xccdf_path = common.SSG_DIR + common.SSG_SDS
+        self._addon_data.content_path = common.SSG_DIR + common.SSG_SDS
         self._fetch_data_and_initialize()

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -284,7 +284,7 @@ class OSCAPSpoke(NormalSpoke):
         # if no content was specified and SSG is available, use it
         if not self._addon_data.content_type and common.ssg_available():
             self._addon_data.content_type = "scap-security-guide"
-            self._addon_data.content_path = common.SSG_DIR + common.SSG_SDS
+            self._addon_data.content_path = common.SSG_DIR + common.SSG_CONTENT
 
         if not self._addon_data.content_defined:
             # nothing more to be done now, the spoke is ready
@@ -1130,5 +1130,5 @@ class OSCAPSpoke(NormalSpoke):
     def on_use_ssg_clicked(self, *args):
         self._addon_data.clear_all()
         self._addon_data.content_type = "scap-security-guide"
-        self._addon_data.content_path = common.SSG_DIR + common.SSG_SDS
+        self._addon_data.content_path = common.SSG_DIR + common.SSG_CONTENT
         self._fetch_data_and_initialize()

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -284,7 +284,7 @@ class OSCAPSpoke(NormalSpoke):
         # if no content was specified and SSG is available, use it
         if not self._addon_data.content_type and common.ssg_available():
             self._addon_data.content_type = "scap-security-guide"
-            self._addon_data.xccdf_path = common.SSG_DIR + common.SSG_XCCDF
+            self._addon_data.xccdf_path = common.SSG_DIR + common.SSG_SDS
 
         if not self._addon_data.content_defined:
             # nothing more to be done now, the spoke is ready
@@ -1130,5 +1130,5 @@ class OSCAPSpoke(NormalSpoke):
     def on_use_ssg_clicked(self, *args):
         self._addon_data.clear_all()
         self._addon_data.content_type = "scap-security-guide"
-        self._addon_data.xccdf_path = common.SSG_DIR + common.SSG_XCCDF
+        self._addon_data.xccdf_path = common.SSG_DIR + common.SSG_SDS
         self._fetch_data_and_initialize()

--- a/org_fedora_oscap/ks/oscap.py
+++ b/org_fedora_oscap/ks/oscap.py
@@ -280,7 +280,7 @@ class OSCAPdata(AddonData):
                 msg = "SCAP Security Guide not found on the system"
                 raise KickstartValueError(msg)
 
-            self.content_path = common.SSG_DIR + common.SSG_SDS
+            self.content_path = common.SSG_DIR + common.SSG_CONTENT
 
     @property
     def content_defined(self):

--- a/org_fedora_oscap/ks/oscap.py
+++ b/org_fedora_oscap/ks/oscap.py
@@ -91,7 +91,7 @@ class OSCAPdata(AddonData):
         self.datastream_id = ""
         self.xccdf_id = ""
         self.profile_id = ""
-        self.xccdf_path = ""
+        self.content_path = ""
         self.cpe_path = ""
         self.tailoring_path = ""
 
@@ -128,8 +128,8 @@ class OSCAPdata(AddonData):
             ret += "\n%s" % key_value_pair("datastream-id", self.datastream_id)
         if self.xccdf_id:
             ret += "\n%s" % key_value_pair("xccdf-id", self.xccdf_id)
-        if self.xccdf_path and self.content_type != "scap-security-guide":
-            ret += "\n%s" % key_value_pair("xccdf-path", self.xccdf_path)
+        if self.content_path and self.content_type != "scap-security-guide":
+            ret += "\n%s" % key_value_pair("content-path", self.content_path)
         if self.cpe_path:
             ret += "\n%s" % key_value_pair("cpe-path", self.cpe_path)
         if self.tailoring_path:
@@ -176,9 +176,9 @@ class OSCAPdata(AddonData):
         # need to be checked?
         self.profile_id = value
 
-    def _parse_xccdf_path(self, value):
+    def _parse_content_path(self, value):
         # need to be checked?
-        self.xccdf_path = value
+        self.content_path = value
 
     def _parse_cpe_path(self, value):
         # need to be checked?
@@ -214,10 +214,11 @@ class OSCAPdata(AddonData):
 
         actions = {"content-type": self._parse_content_type,
                    "content-url": self._parse_content_url,
+                   "content-path": self._parse_content_path,
                    "datastream-id": self._parse_datastream_id,
                    "profile": self._parse_profile_id,
                    "xccdf-id": self._parse_xccdf_id,
-                   "xccdf-path": self._parse_xccdf_path,
+                   "xccdf-path": self._parse_content_path,
                    "cpe-path": self._parse_cpe_path,
                    "tailoring-path": self._parse_tailoring_path,
                    "fingerprint": self._parse_fingerprint,
@@ -255,7 +256,7 @@ class OSCAPdata(AddonData):
         if not self.profile_id:
             self.profile_id = "default"
 
-        if self.content_type in ("rpm", "archive") and not self.xccdf_path:
+        if self.content_type in ("rpm", "archive") and not self.content_path:
             msg = "Path to the XCCDF file has to be given if content in RPM "\
                   "or archive is used"
             raise KickstartValueError(msg)
@@ -279,7 +280,7 @@ class OSCAPdata(AddonData):
                 msg = "SCAP Security Guide not found on the system"
                 raise KickstartValueError(msg)
 
-            self.xccdf_path = common.SSG_DIR + common.SSG_SDS
+            self.content_path = common.SSG_DIR + common.SSG_SDS
 
     @property
     def content_defined(self):
@@ -327,10 +328,10 @@ class OSCAPdata(AddonData):
                                     self.content_name)
         elif self.content_type == "scap-security-guide":
             # SSG is not copied to the standard place
-            return self.xccdf_path
+            return self.content_path
         else:
             return utils.join_paths(common.INSTALLATION_CONTENT_DIR,
-                                    self.xccdf_path)
+                                    self.content_path)
 
     @property
     def postinst_content_path(self):
@@ -341,10 +342,10 @@ class OSCAPdata(AddonData):
                                     self.content_name)
         elif self.content_type in ("rpm", "scap-security-guide"):
             # no path magic in case of RPM (SSG is installed as an RPM)
-            return self.xccdf_path
+            return self.content_path
         else:
             return utils.join_paths(common.TARGET_CONTENT_DIR,
-                                    self.xccdf_path)
+                                    self.content_path)
 
     @property
     def preinst_tailoring_path(self):
@@ -380,7 +381,7 @@ class OSCAPdata(AddonData):
             # extract the content
             common.extract_data(self.raw_preinst_content_path,
                                 common.INSTALLATION_CONTENT_DIR,
-                                [self.xccdf_path])
+                                [self.content_path])
 
         rules = common.get_fix_rules_pre(self.profile_id,
                                          self.preinst_content_path,

--- a/org_fedora_oscap/ks/oscap.py
+++ b/org_fedora_oscap/ks/oscap.py
@@ -279,7 +279,7 @@ class OSCAPdata(AddonData):
                 msg = "SCAP Security Guide not found on the system"
                 raise KickstartValueError(msg)
 
-            self.xccdf_path = common.SSG_DIR + common.SSG_XCCDF
+            self.xccdf_path = common.SSG_DIR + common.SSG_SDS
 
     @property
     def content_defined(self):

--- a/tests/ks_oscap_test.py
+++ b/tests/ks_oscap_test.py
@@ -28,7 +28,7 @@ class ParsingTest(unittest.TestCase):
         self.assertEqual(self.oscap_data.datastream_id, "id_datastream_1")
         self.assertEqual(self.oscap_data.xccdf_id, "id_xccdf_new")
         self.assertEqual(self.oscap_data.content_path,
-                         "/usr/share/oscap/xccdf.xml")
+                         "/usr/share/oscap/testing_ds.xml")
         self.assertEqual(self.oscap_data.cpe_path, "/usr/share/oscap/cpe.xml")
         self.assertEqual(self.oscap_data.profile_id, "Web Server")
         self.assertEqual(self.oscap_data.content_name, "hardening.xml")

--- a/tests/ks_oscap_test.py
+++ b/tests/ks_oscap_test.py
@@ -27,7 +27,7 @@ class ParsingTest(unittest.TestCase):
                          "https://example.com/hardening.xml")
         self.assertEqual(self.oscap_data.datastream_id, "id_datastream_1")
         self.assertEqual(self.oscap_data.xccdf_id, "id_xccdf_new")
-        self.assertEqual(self.oscap_data.xccdf_path,
+        self.assertEqual(self.oscap_data.content_path,
                          "/usr/share/oscap/xccdf.xml")
         self.assertEqual(self.oscap_data.cpe_path, "/usr/share/oscap/cpe.xml")
         self.assertEqual(self.oscap_data.profile_id, "Web Server")
@@ -287,12 +287,12 @@ class ArchiveHandlingTest(unittest.TestCase):
         # content paths should be returned as expected
         self.assertEqual(self.oscap_data.preinst_content_path,
                          os.path.normpath(common.INSTALLATION_CONTENT_DIR +
-                                          self.oscap_data.xccdf_path))
+                                          self.oscap_data.content_path))
 
-        # when using rpm, xccdf_path doesn't change for the post-installation
+        # when using rpm, content_path doesn't change for the post-installation
         # phase
         self.assertEqual(self.oscap_data.postinst_content_path,
-                         self.oscap_data.xccdf_path)
+                         self.oscap_data.content_path)
 
     def ds_raw_content_paths_test(self):
         for line in ["content-url = http://example.com/scap_content.xml",

--- a/tests/ks_oscap_test.py
+++ b/tests/ks_oscap_test.py
@@ -14,7 +14,7 @@ class ParsingTest(unittest.TestCase):
                      "content-url = \"https://example.com/hardening.xml\"\n",
                      "datastream-id = id_datastream_1\n",
                      "xccdf-id = id_xccdf_new\n",
-                     "xccdf-path = /usr/share/oscap/xccdf.xml",
+                     "content-path = /usr/share/oscap/testing_ds.xml",
                      "cpe-path = /usr/share/oscap/cpe.xml",
                      "tailoring-path = /usr/share/oscap/tailoring.xml",
                      "profile = \"Web Server\"\n",
@@ -64,7 +64,7 @@ class ParsingTest(unittest.TestCase):
                          "    content-url = https://example.com/hardening.xml\n"
                          "    datastream-id = id_datastream_1\n"
                          "    xccdf-id = id_xccdf_new\n"
-                         "    xccdf-path = /usr/share/oscap/xccdf.xml\n"
+                         "    content-path = /usr/share/oscap/testing_ds.xml\n"
                          "    cpe-path = /usr/share/oscap/cpe.xml\n"
                          "    tailoring-path = /usr/share/oscap/tailoring.xml\n"
                          "    profile = Web Server\n"
@@ -80,6 +80,36 @@ class ParsingTest(unittest.TestCase):
 
         str_ret2 = str(self.oscap_data)
         self.assertEqual(str_ret, str_ret2)
+
+
+class BackwardCompatibilityParsingTest(unittest.TestCase):
+    def setUp(self):
+        self.oscap_data = OSCAPdata("org_fedora_oscap")
+        for line in ["content-type = datastream\n",
+                     "content-url = \"https://example.com/hardening.xml\"\n",
+                     "datastream-id = id_datastream_1\n",
+                     "xccdf-id = id_xccdf_new\n",
+                     "xccdf-path = /usr/share/oscap/xccdf.xml",
+                     "cpe-path = /usr/share/oscap/cpe.xml",
+                     "tailoring-path = /usr/share/oscap/tailoring.xml",
+                     "profile = \"Web Server\"\n",
+                     ]:
+            self.oscap_data.handle_line(line)
+
+    def str_test(self):
+        str_ret = str(self.oscap_data)
+        self.assertEqual(str_ret,
+                         "%addon org_fedora_oscap\n"
+                         "    content-type = datastream\n"
+                         "    content-url = https://example.com/hardening.xml\n"
+                         "    datastream-id = id_datastream_1\n"
+                         "    xccdf-id = id_xccdf_new\n"
+                         "    content-path = /usr/share/oscap/xccdf.xml\n"
+                         "    cpe-path = /usr/share/oscap/cpe.xml\n"
+                         "    tailoring-path = /usr/share/oscap/tailoring.xml\n"
+                         "    profile = Web Server\n"
+                         "%end\n\n"
+                         )
 
 
 class IncompleteDataTest(unittest.TestCase):


### PR DESCRIPTION
When loading content from SCAP Security Guide, we should use content from the DataStream, not from XCCDF file.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1465402
Also fixes #41 
