### PR TITLE
Fix password rules cleaning

### DIFF
--- a/org_fedora_oscap/rule_handling.py
+++ b/org_fedora_oscap/rule_handling.py
@@ -472,6 +472,9 @@ class PasswdRules(RuleHandler):
             else:
                 ret = []
 
+        if report_only:
+            return ret
+
         # set the policy in any case (so that a weaker password is not entered)
         pw_policy = ksdata.anaconda.pwpolicy.get_policy("root")
         if pw_policy is None:


### PR DESCRIPTION
During manual installation when profile affecting password was selected,
selection of another profile did not clear the password requirements.
The method revert_changes didn't work because the saved old password
length was overwritten each time when eval_rules was invoked.
Saved old password length should be overwritten only if the eval_rules
method is called with report_only set to False.
Fixes rhbz #1374181 and issue #52.