### PR TITLE
Fix a traceback in os.path.exists

### DIFF
--- a/org_fedora_oscap/ks/oscap.py
+++ b/org_fedora_oscap/ks/oscap.py
@@ -352,7 +352,7 @@ class OSCAPdata(AddonData):
         """Path to the pre-installation tailoring file (if any)"""
 
         if not self.tailoring_path:
-            return None
+            return ""
 
         return utils.join_paths(common.INSTALLATION_CONTENT_DIR,
                                 self.tailoring_path)
@@ -362,7 +362,7 @@ class OSCAPdata(AddonData):
         """Path to the post-installation tailoring file (if any)"""
 
         if not self.tailoring_path:
-            return None
+            return ""
 
         if self.content_type == "rpm":
             # no path magic in case of RPM


### PR DESCRIPTION
Fixes rhbz #1520276. Addressing:

```
Traceback (most recent call first):
  File "/usr/lib64/python2.7/genericpath.py", line 18, in exists
    os.stat(path)
  File "/usr/share/anaconda/addons/org_fedora_oscap/ks/oscap.py", line 546, in execute
    if os.path.exists(self.preinst_tailoring_path):
  File "/usr/lib64/python2.7/site-packages/pyanaconda/addons.py", line 88, in execute
    v.execute(storage, ksdata, instClass, users, payload)
  File "/usr/lib64/python2.7/site-packages/pyanaconda/install.py", line 109, in doConfiguration
    ksdata.addons.execute(storage, ksdata, instClass, u, payload)
  File "/usr/lib64/python2.7/threading.py", line 765, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/usr/lib64/python2.7/site-packages/pyanaconda/threads.py", line 227, in run
    threading.Thread.run(self, *args, **kwargs)
TypeError: coercing to Unicode: need string or buffer, NoneType found
```