### PR TITLE
Define translation domain in OSCAPSpoke

### DIFF
--- a/org_fedora_oscap/gui/spokes/oscap.glade
+++ b/org_fedora_oscap/gui/spokes/oscap.glade
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.18.3 -->
-<interface>
+<interface domain="oscap-anaconda-addon">
   <requires lib="gtk+" version="3.0"/>
   <requires lib="AnacondaWidgets" version="1.0"/>
   <object class="GtkListStore" id="changesStore">

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -158,6 +158,9 @@ class OSCAPSpoke(NormalSpoke):
     # name of the file providing help content for this spoke
     helpFile = "SecurityPolicySpoke.xml"
 
+    # domain of oscap-anaconda-addon translations
+    translationDomain = "oscap-anaconda-addon"
+
     # category this spoke belongs to
     category = SystemCategory
 


### PR DESCRIPTION
UI doesn't show translations if translation domain is not defined.

Below is screenshot of UI with translations.
![screenshot from 2018-02-01 20-39-08](https://user-images.githubusercontent.com/7460169/35699322-fcda8324-078f-11e8-8fe4-119346b6118f.png)


