### PR TITLE
Clarify that missing partitions need to be created before selecting profile

### DIFF
--- a/org_fedora_oscap/rule_handling.py
+++ b/org_fedora_oscap/rule_handling.py
@@ -345,7 +345,9 @@ class PartRule(RuleHandler):
         messages = []
         if self._mount_point not in storage.mountpoints:
             msg = _("%s must be on a separate partition or logical "
-                    "volume" % self._mount_point)
+                    "volume and has to be created in the "
+                    "partitioning layout before selecting a "
+                    "security profile." % self._mount_point)
             messages.append(RuleMessage(self.__class__,
                                         common.MESSAGE_TYPE_FATAL, msg))
 

--- a/org_fedora_oscap/rule_handling.py
+++ b/org_fedora_oscap/rule_handling.py
@@ -344,10 +344,10 @@ class PartRule(RuleHandler):
 
         messages = []
         if self._mount_point not in storage.mountpoints:
-            msg = _("%s must be on a separate partition or logical "
+            msg = _("{0} must be on a separate partition or logical "
                     "volume and has to be created in the "
-                    "partitioning layout before selecting a "
-                    "security profile." % self._mount_point)
+                    "partitioning layout before installation can occur "
+                    "with a security profile").format(self._mount_point)
             messages.append(RuleMessage(self.__class__,
                                         common.MESSAGE_TYPE_FATAL, msg))
 


### PR DESCRIPTION
Message was a source of confusion for some users attempting to create a profile. They thought it was an error and didn't realize that a missing mount point had to be created in the installation.