### PR TITLE
Add new kdump --disable rule handling

### DIFF
--- a/org_fedora_oscap/rule_handling.py
+++ b/org_fedora_oscap/rule_handling.py
@@ -721,33 +721,31 @@ class KdumpRules(RuleHandler):
 
         if self._kdump_enabled == None:
             return []
-
-        if self._kdump_enabled == False:
+        elif self._kdump_enabled == False:
             msg = _("Kdump will be disabled on startup")
-        if self._kdump_enabled == True:
+        elif self._kdump_enabled == True:
             msg = _("Kdump will be enabled on startup")
 
         messages.append(RuleMessage(self.__class__,
                                     common.MESSAGE_TYPE_INFO, msg))
 
-        try:
-            if not report_only:
+        if not report_only:
+            try:
                 ksdata.addons.com_redhat_kdump.enabled = self._kdump_enabled
-        except AttributeError:
-            log.warning("com_redhat_kdump is not installed. "
-                        "Skipping kdump configuration")
+            except AttributeError:
+                log.warning("com_redhat_kdump is not installed. "
+                            "Skipping kdump configuration")
 
         return messages
 
     def revert_changes(self, ksdata, storage):
         """:see: RuleHander.revert_changes"""
 
-        try:
-            if ksdata.addons.com_redhat_kdump.enabled == False or \
-               self._kdump_enabled == False:
+        if self._kdump_enabled == False:
+            try:
                 ksdata.addons.com_redhat_kdump.enabled = True
-        except AttributeError:
-            log.warning("com_redhat_kdump is not installed. "
-                        "Skipping reverting kdump configuration")
+            except AttributeError:
+                log.warning("com_redhat_kdump is not installed. "
+                            "Skipping reverting kdump configuration")
 
         self._kdump_enabled = None

--- a/org_fedora_oscap/rule_handling.py
+++ b/org_fedora_oscap/rule_handling.py
@@ -729,3 +729,5 @@ class KdumpRules(RuleHandler):
 
         if not self._kdump_enabled:
             ksdata.addons.com_redhat_kdump.enabled = True
+
+        self._kdump_enabled = True

--- a/org_fedora_oscap/rule_handling.py
+++ b/org_fedora_oscap/rule_handling.py
@@ -81,7 +81,7 @@ BOOTLOADER_RULE_PARSER.add_option("--passwd", dest="passwd", action="store_true"
 
 KDUMP_RULE_PARSER = ModifiedOptionParser()
 KDUMP_RULE_PARSER.add_option("--disable", action="store_false",
-                             dest="enabled", help="Disable kdump")
+                             dest="enabled", default=True)
 
 
 class RuleHandler(object):

--- a/org_fedora_oscap/rule_handling.py
+++ b/org_fedora_oscap/rule_handling.py
@@ -692,6 +692,7 @@ class KdumpRules(RuleHandler):
         """Constructor setting the initial value of attributes."""
 
         self._kdump_enabled = None
+        self._kdump_default_enabled = None
 
     def kdump_enabled(self, kdenabled):
         """Enable or Disable Kdump"""
@@ -731,6 +732,9 @@ class KdumpRules(RuleHandler):
 
         if not report_only:
             try:
+                if self._kdump_default_enabled == None:
+                    # Kdump addon default startup setting
+                    self._kdump_default_enabled = ksdata.addons.com_redhat_kdump.enabled
                 ksdata.addons.com_redhat_kdump.enabled = self._kdump_enabled
             except AttributeError:
                 log.warning("com_redhat_kdump is not installed. "
@@ -741,11 +745,16 @@ class KdumpRules(RuleHandler):
     def revert_changes(self, ksdata, storage):
         """:see: RuleHander.revert_changes"""
 
-        if self._kdump_enabled == False:
-            try:
+        try:
+            if self._kdump_enabled == False and \
+               self._kdump_default_enabled == True:
                 ksdata.addons.com_redhat_kdump.enabled = True
-            except AttributeError:
-                log.warning("com_redhat_kdump is not installed. "
-                            "Skipping reverting kdump configuration")
+            elif self._kdump_enabled == True and \
+                 self._kdump_default_enabled == False:
+                ksdata.addons.com_redhat_kdump.enabled = False
+        except AttributeError:
+            log.warning("com_redhat_kdump is not installed. "
+                        "Skipping reverting kdump configuration")
 
         self._kdump_enabled = None
+        self._kdump_default_enabled = None

--- a/org_fedora_oscap/rule_handling.py
+++ b/org_fedora_oscap/rule_handling.py
@@ -744,12 +744,8 @@ class KdumpRules(RuleHandler):
         """:see: RuleHander.revert_changes"""
 
         try:
-            if self._kdump_enabled == False and \
-               self._kdump_default_enabled == True:
-                ksdata.addons.com_redhat_kdump.enabled = True
-            elif self._kdump_enabled == True and \
-                 self._kdump_default_enabled == False:
-                ksdata.addons.com_redhat_kdump.enabled = False
+            if self._kdump_enabled is not None:
+                ksdata.addons.com_redhat_kdump.enabled = self._kdump_default_enabled
         except AttributeError:
             log.warning("com_redhat_kdump is not installed. "
                         "Skipping reverting kdump configuration")

--- a/org_fedora_oscap/rule_handling.py
+++ b/org_fedora_oscap/rule_handling.py
@@ -735,14 +735,19 @@ class KdumpRules(RuleHandler):
                 ksdata.addons.com_redhat_kdump.enabled = self._kdump_enabled
         except AttributeError:
             log.warning("com_redhat_kdump is not installed. "
-                        "Skipping disabling kdump configuration")
+                        "Skipping kdump configuration")
 
         return messages
 
     def revert_changes(self, ksdata, storage):
         """:see: RuleHander.revert_changes"""
 
-        if self._kdump_enabled == False:
-            ksdata.addons.com_redhat_kdump.enabled = True
+        try:
+            if ksdata.addons.com_redhat_kdump.enabled == False or \
+               self._kdump_enabled == False:
+                ksdata.addons.com_redhat_kdump.enabled = True
+        except AttributeError:
+            log.warning("com_redhat_kdump is not installed. "
+                        "Skipping reverting kdump configuration")
 
         self._kdump_enabled = None

--- a/org_fedora_oscap/rule_handling.py
+++ b/org_fedora_oscap/rule_handling.py
@@ -697,10 +697,8 @@ class KdumpRules(RuleHandler):
     def kdump_enabled(self, kdenabled):
         """Enable or Disable Kdump"""
 
-        if kdenabled == True:
-            self._kdump_enabled = True
-        if kdenabled == False:
-            self._kdump_enabled = False
+        if kdenabled is not None:
+            kdenabled = self._kdump_enabled
 
     def __str__(self):
         """Standard method useful for debugging and testing."""

--- a/org_fedora_oscap/rule_handling.py
+++ b/org_fedora_oscap/rule_handling.py
@@ -698,17 +698,17 @@ class KdumpRules(RuleHandler):
         """Enable or Disable Kdump"""
 
         if kdenabled is not None:
-            kdenabled = self._kdump_enabled
+            self._kdump_enabled = kdenabled
 
     def __str__(self):
         """Standard method useful for debugging and testing."""
 
         ret = "kdump"
 
-        if self._kdump_enabled == True:
+        if self._kdump_enabled is True:
             ret += " --enable"
 
-        if self._kdump_enabled == False:
+        if self._kdump_enabled is False:
             ret += " --disable"
 
         return ret
@@ -718,11 +718,11 @@ class KdumpRules(RuleHandler):
 
         messages = []
 
-        if self._kdump_enabled == None:
+        if self._kdump_enabled is None:
             return []
-        elif self._kdump_enabled == False:
+        elif self._kdump_enabled is False:
             msg = _("Kdump will be disabled on startup")
-        elif self._kdump_enabled == True:
+        elif self._kdump_enabled is True:
             msg = _("Kdump will be enabled on startup")
 
         messages.append(RuleMessage(self.__class__,
@@ -730,7 +730,7 @@ class KdumpRules(RuleHandler):
 
         if not report_only:
             try:
-                if self._kdump_default_enabled == None:
+                if self._kdump_default_enabled is None:
                     # Kdump addon default startup setting
                     self._kdump_default_enabled = ksdata.addons.com_redhat_kdump.enabled
                 ksdata.addons.com_redhat_kdump.enabled = self._kdump_enabled


### PR DESCRIPTION
- Adds new `kdump --disable` handling that can be added to anaconda scripts
  to be able to disable kdump from OSCAP content