### PR TITLE
Replaced the spec file with spec file closer to the RHEL7 spec.

### DIFF
--- a/oscap-anaconda-addon.spec
+++ b/oscap-anaconda-addon.spec
@@ -1,10 +1,4 @@
-%if 0%{?fedora} >= 25
-%define _py python3
-%endif
-
-%if 0%{?rhel} || 0%{?fedora} < 25
-%define _py python
-%endif
+%global _default_patch_flags --no-backup-if-mismatch
 
 Name:           oscap-anaconda-addon
 Version:        0.9
@@ -12,7 +6,7 @@ Release:        1%{?dist}
 Summary:        Anaconda addon integrating OpenSCAP to the installation process
 
 License:        GPLv2+
-URL:            https://github.com/OpenSCAP/oscap-anaconda-addon.git
+URL:            https://www.open-scap.org/tools/oscap-anaconda-addon/
 
 # This is a Red Hat maintained package which is specific to
 # our distribution.
@@ -24,22 +18,15 @@ Source0:        %{name}-%{version}.tar.gz
 
 BuildArch:      noarch
 BuildRequires:  gettext
-%if 0%{?fedora} >= 25
-BuildRequires:  %{_py}-devel
-BuildRequires:  %{_py}-mock
-BuildRequires:  %{_py}-kickstart
-%else
-BuildRequires:	%{_py}2-devel
-BuildRequires:  %{_py}2-mock
-BuildRequires:  pykickstart
-%endif
-BuildRequires:  %{_py}-nose
-BuildRequires:  openscap openscap-utils openscap-%{_py}
-BuildRequires:  %{_py}-cpio
-BuildRequires:  anaconda >= 21.48.22.99
-Requires:       anaconda >= 21.48.22.99
-Requires:       openscap openscap-utils openscap-%{_py}
-Requires:       %{_py}-cpio
+BuildRequires:	python2-devel
+#BuildRequires:  python-mock
+#BuildRequires:  python-nose
+#BuildRequires:  python-cpio
+BuildRequires:  anaconda-core >= 21.48.22.99
+Requires:       anaconda-core >= 21.48.22.99
+Requires:       openscap openscap-utils openscap-python
+Requires:       python-cpio
+Requires:       scap-security-guide
 
 %description
 This is an addon that integrates OpenSCAP utilities with the Anaconda installer
@@ -47,8 +34,7 @@ and allows installation of systems following restrictions given by a SCAP
 content.
 
 %prep
-%setup -q
-
+%setup -q -n %{name}-%{version}
 
 %build
 
@@ -66,83 +52,173 @@ make install DESTDIR=%{buildroot}
 %doc COPYING ChangeLog README.md
 
 %changelog
-* Mon Nov 13 2017 Martin Preisler <mpreisle@redhat.com> - 0.8-1
-- Log password policy changes
-- Log openscap errors
-- Hide default profile if it's empty
-- Parse HTML tags in SCAP content formatting
-- Allow file:// URL for SCAP content
-- Copy tailoring file to target when applying SCAP policy
-- Catch Anaconda remediation syntax errors without causing Anaconda to crash (#1452667)
-- Fixed password rule handling
-- Minor bugfixes
+* Mon Jun 11 2018 Watson Yuuma Sato <wsato@redhat.com> - 0.9-1
+- Rebase to the upstream version 0.9
+- Drop patch that fixed selection of RHEL Alternate Architecture datastream
+  Resolves: rhbz#1564903
+- Update project URL
+  Resolves: rhbz#1502379
 
-* Fri Sep 08 2017 Gabriel Alford <galford@redhat.com> - 0.7-3
-- Add python3 support to .spec file and upstream code
+* Tue Feb 06 2018 Watson Yuuma Sato <wsato@redhat.com> - 0.8-4
+- Define translation domain of oscap-anaconda-addon
+  Resolves: rhbz#1540302
 
-* Mon Feb 13 2017 Jiri Konecny <jkonecny@redhat.com> - 0.7-2
-- Fix URL which is now poiting to GitHub instead of fedorahosted
+* Tue Dec 12 2017 Watson Yuuma Sato <wsato@redhat.com> - 0.8-3
+- Return empty string when there is no tailoring file
+  Resolves: rhbz#1520276
 
-* Wed Jan 07 2015 Vratislav Podzimek <vpodzime@redhat.com> - 0.7-1
-- Adapt to changes in Anaconda
-- Add *~ to EXCLUDES (#1081735)
-- Set active profile when doing refresh
-- Set fetching flag to False when content processing fails
-- Fix the message when policy is not applied
-- Change spoke's name to SECURITY POLICY
-- Define name of the spoke window
-- Set fetching flag to False when extraction error happens
-- Remove code that was pushed to the anaconda's sources
-- Update spec file from downstream
+* Mon Dec 11 2017 Watson Sato <wsato@redhat.com> - 0.8-2
+- Add japanese translation
+- Update other translations
+  Resolves: rhbz#1481190
+- Fix selection of RHEL datastream
+  Resolves: rhbz#1520358
 
-* Fri Feb 28 2014 Vratislav Podzimek <vpodzime@redhat.com> - 0.6-2
-- Rebuild with building issues fixed
+* Mon Nov 27 2017 Watson Sato <wsato@redhat.com> - 0.8-1
+- Rebase to the upstream version 0.8
+  Related: rhbz#1472419
 
-* Fri Feb 28 2014 Vratislav Podzimek <vpodzime@redhat.com> - 0.6-1
-- Getting status needs to run in the main thread
-- Grab focus for the URL entry after switching notebook page
-- Clear rule data when unselecting profile
-- Update message as part of the initialization
-- Add BuildRequires: gettext
-- Include translations in the tarball and RPM
+* Tue May 30 2017 Watson Sato <wsato@redhat.com> - 0.7-15
+- Add japanese translation
+- Update other translations
+  Resolves: rhbz#1383181
 
-* Fri Feb 28 2014 Vratislav Podzimek <vpodzime@redhat.com> - 0.5-1
-- Allow users to change content
-- Show and hide control buttons properly
-- Fix sensitivity of the URL entry and fetch button
-- Add the button allowing users to use SSG content if available
-- Fix listing python sources when creating potfile and regenerate it
-- Omit the %addon section from kickstart in dry-run mode
-- Implement the dry-run mode in the GUI (trac#2)
-- Add UI elements for content changing and dry-run mode
-- Check content_defined instead of content_url in the GUI code
-- First select the profile, then update the message store
-- Remove unused import
-- Ignore some more temporary/backup files
-- If no content is specified and SSG is available, use it
-- New special content type -- SCAP Security Guide
-- Fix name of the property used when doing fingerprint check
-- Get rid of an unused variable
-- Fix data fetch locking to work properly with kickstart installations
-- Use 'anonymous:' if no username and password is given for FTP
-- Initial version of the translations template file
-- First steps to dry-run mode
-- Fix main notebook tabs
-- Make translations work
-- Manipulation with the i18n related files
-- If no profile is given, default to default
-- Ignore updates.img and its auxiliary directory
-- Catch only fetching errors from the fetching thread
-- Do not allow multiple simultaneous fetches/initializations
-- Prevent user from changing the URL while we try to fetch from it
-- Add support for the Default profile
-- Support FTP as a content source (#1050980)
-- React properly on archive extraction failure
-- Refactor the code pre-processing the fetched content
-- Unify exceptions from archive extraction
-- Make pylint check mandatory to pass
-- Support for hash based content integrity checking
+* Thu Apr 20 2017 Raphael Sanchez Prudencio <rsprudencio@redhat.com> - 0.7-14
+- Fixed gtk warning messages when anaconda is starting.
+  Resolves: rhbz#1437106
 
+* Tue Mar 28 2017 Martin Preisler <mpreisle@redhat.com> - 0.7-13
+- Avoid long delay before a GeoIP related timeout in case internet is not available
+  Resolves: rhbz#1379479
+
+* Tue Sep 13 2016 Vratislav Podzimek <vpodzime@redhat.com> - 0.7-12
+- Properly handle tailoring files for datastreams
+  Resolves: rhbz#1364929
+
+* Thu Aug 25 2016 Vratislav Podzimek <vpodzime@redhat.com> - 0.7-11
+- Don't require blank stderr when running the oscap tool
+  Resolves: rhbz#1360765
+- Beware of the invalid profiles
+  Resolves: rhbz#1365130
+- Properly set the seen property for root passwords
+  Resolves: rhbz#1357603
+
+* Thu Jun 30 2016 Vratislav Podzimek <vpodzime@redhat.com> - 0.7-10
+- Clear spoke's info before setting an error
+  Resolves: rhbz#1349446
+
+* Wed Jun  1 2016 Vratislav Podzimek <vpodzime@redhat.com> - 0.7-9
+- Use the System hub category provided by Anaconda
+  Resolves: rhbz#1269211
+- Wait for Anaconda to settle before evaluation
+  Resolves: rhbz#1265552
+- Make the changes overview scrollable and smaller
+  Related: rhbz#1263582
+- Make the list of profiles scrollable
+  Resolves: rhbz#1263582
+- Do not try to create a single file multiple times
+  Related: rhbz#1263315
+- Avoid crashes on extraction errors
+  Resolves: rhbz#1263315
+- Disable GPG checks when installing content to the system
+  Resolves: rhbz#1263216
+- Allow fixing root password in graphical installations
+  Resolves: rhbz#1265116
+- Enforce the minimal root password length
+  Resolves: rhbz#1238281
+- Just report misconfiguration instead of crashing in text mode
+  Resolves: rhbz#1263207
+- Do not verify SSL if inst.noverifyssl was given
+  Resolves: rhbz#1263257
+- Also catch data_fetch.DataFetchError when trying to get content
+  Resolves: rhbz#1263239
+- Use new method signature with payload class
+  Related: rhbz#1288636
+
+* Wed Sep 16 2015 Vratislav Podzimek <vpodzime@redhat.com> - 0.7-8
+- Do not remove the root password behind user's back
+  Resolves: rhbz#1263254
+
+* Mon Sep 7 2015 Vratislav Podzimek <vpodzime@redhat.com> - 0.7-7
+- Completely skip the execute() part if no profile is selected
+  Resolves: rhbz#1254973
+
+* Mon Aug 24 2015 Vratislav Podzimek <vpodzime@redhat.com> - 0.7-6
+- Specify the name of the help content file
+  Resolves: rhbz#1254884
+- Skip files unrecognized by the 'oscap info' command
+  Resolves: rhbz#1255075
+- Only allow DS and XCCDF ID selection if it makes sense
+  Resolves: rhbz#1254876
+
+* Tue Aug 4 2015 Vratislav Podzimek <vpodzime@redhat.com> - 0.7-5
+- Make sure DS and XCCDF ID lists are correctly refreshed
+  Resolves: rhbz#1240946
+- Make sure the DS and XCCDF ID combo boxes are visible for DS content
+  Resolves: rhbz#1249951
+- Try to load the OSCAP session early for DS content
+  Resolves: rhbz#1247654
+- Test preinst_content_path before raw_preinst_content_path
+  Resolves: rhbz#1249937
+- Clear any error if switching to the dry-run mode
+  Related: rhbz#1247677
+- Do not continue with and invalid profile ID
+  Resolves: rhbz#1247677
+- Cover all potential places with a non-main thread changing Gtk stuff
+  Resolves: rhbz#1240967
+
+* Thu Jul 23 2015 Vratislav Podzimek <vpodzime@redhat.com> - 0.7-4
+- Better handle and report erroneous states
+  Resolves: rhbz#1241064
+- Make sure (some more) GUI actions run in the main thread
+  Resolves: rhbz#1240967
+- Beware of RPM->cpio entries' paths having absolute paths
+  Related: rhbz#1241064
+- Only output the kickstart section with content and profile set
+  Resolves: rhbz#1241395
+- Just report integrity check failure instead of traceback
+  Resolves: rhbz#1240710
+- Properly react on download/loading issues in text+kickstart mode
+  Related: rhbz#1240710
+- Fetch and process the content even if GUI doesn't take care of it
+  Resolves: rhbz#1240625
+
+* Tue Jul 7 2015 Vratislav Podzimek <vpodzime@redhat.com> - 0.7-3
+- Do not output redundant/invalid fields for the SSG content (vpodzime)
+  Resolves: rhbz#1240285
+- Better handle unsupported URL types (vpodzime)
+  Resolves: rhbz#1232631
+- React better on network issues (vpodzime)
+  Resolves: rhbz#1236657
+- Improve the description of the default profile (vpodzime)
+  Resolves: rhbz#1238080
+- Use the openscap-scanner package instead of openscap-utils (vpodzime)
+  Resolves: rhbz#1240249
+- Better handle the case with no profile selected (vpodzime)
+  Resolves: rhbz#1235750
+- Add newline and one blank line after the %%addon section (vpodzime)
+  Resolves: rhbz#1238267
+- Word-wrap profile descriptions (vpodzime)
+  Resolves: rhbz#1236644
+
+* Wed Jun 17 2015 Vratislav Podzimek <vpodzime@redhat.com> - 0.7-2
+- Add gettext to BuildRequires (vpodzime)
+  Related: rhbz#1204640
+
+* Tue Jun 16 2015 Vratislav Podzimek <vpodzime@redhat.com> - 0.7-1
+- Rebase to the upstream version 0.7
+  Related: rhbz#1204640
+
+* Tue Apr 28 2015 Vratislav Podzimek <vpodzime@redhat.com> - 0.6-1
+- Rebase to the upstream version 0.6
+  Resolves: rhbz#1204640
+
+* Mon Aug 04 2014 Vratislav Podzimek <vpodzime@redhat.com> - 0.4-3
+- Don't distribute backup files
+  Resolves: rhbz#1065906
+* Wed Jan 15 2014 Vratislav Podizmek <vpodzime@redhat.com> - 0.4-2
+- Skip running tests on RHEL builds
+  Related: rhbz#1035662
 * Tue Jan 14 2014 Vratislav Podzimek <vpodzime@redhat.com> - 0.4-1
 - Beware of running Gtk actions from a non-main thread
 - Fix path to the tailoring file when getting rules


### PR DESCRIPTION
There feeling in our team is that it is beneficial to have the upstream `.spec` files more similar to what we actually use downstream.
@redhatrises AFAIK, you were the person behind having `.spec` files to take part in PR gating, do you still like that idea? The .spec file in master and rhel7 are going to diverge.