### PR TITLE
Set help id for the OSCAP addon provided spoke (#1638068)

### DIFF
--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -179,8 +179,8 @@ class OSCAPSpoke(NormalSpoke):
     # name of the .glade file in the same directory as this source
     uiFile = "oscap.glade"
 
-    # name of the file providing help content for this spoke
-    helpFile = "SecurityPolicySpoke.xml"
+    # id of the help content for this spoke
+    help_id = "SecurityPolicySpoke"
 
     # domain of oscap-anaconda-addon translations
     translationDomain = "oscap-anaconda-addon"


### PR DESCRIPTION
The new Anaconda help system now operates on help ids instead of pointing to
individual files.

So drop the old property and replace it with a proper help_id.

Resolves: rhbz#1638068