### PR TITLE
Remove install classes

### DIFF
--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -196,7 +196,7 @@ class OSCAPSpoke(NormalSpoke):
     title = N_("_SECURITY POLICY")
 
     # methods defined by API and helper methods #
-    def __init__(self, data, storage, payload, instclass):
+    def __init__(self, data, storage, payload):
         """
         :see: pyanaconda.ui.common.Spoke.__init__
         :param data: data object passed to every spoke to load/store data
@@ -207,12 +207,10 @@ class OSCAPSpoke(NormalSpoke):
         :type storage: blivet.Blivet
         :param payload: object storing packaging-related information
         :type payload: pyanaconda.packaging.Payload
-        :param instclass: distribution-specific information
-        :type instclass: pyanaconda.installclass.BaseInstallClass
 
         """
 
-        NormalSpoke.__init__(self, data, storage, payload, instclass)
+        NormalSpoke.__init__(self, data, storage, payload)
         self._addon_data = self.data.addons.org_fedora_oscap
         self._storage = storage
         self._ready = False

--- a/org_fedora_oscap/ks/oscap.py
+++ b/org_fedora_oscap/ks/oscap.py
@@ -390,7 +390,7 @@ class OSCAPdata(AddonData):
         for rule in rules.splitlines():
             self.rule_data.new_rule(rule)
 
-    def setup(self, storage, ksdata, instclass, payload):
+    def setup(self, storage, ksdata, payload):
         """
         The setup method that should make changes to the runtime environment
         according to the data stored in this object.
@@ -401,8 +401,6 @@ class OSCAPdata(AddonData):
         :param ksdata: data parsed from the kickstart file and set in the
                        installation process
         :type ksdata: pykickstart.base.BaseHandler instance
-        :param instclass: distribution-specific information
-        :type instclass: pyanaconda.installclass.BaseInstallClass
 
         """
 
@@ -501,7 +499,7 @@ class OSCAPdata(AddonData):
             if pkg not in ksdata.packages.packageList:
                 ksdata.packages.packageList.append(pkg)
 
-    def execute(self, storage, ksdata, instclass, users, payload):
+    def execute(self, storage, ksdata, users, payload):
         """
         The execute method that should make changes to the installed system. It
         is called only once in the post-install setup phase.

--- a/oscap-anaconda-addon.spec
+++ b/oscap-anaconda-addon.spec
@@ -22,8 +22,8 @@ BuildRequires:  python3-mock
 BuildRequires:  python3-nose
 BuildRequires:  python3-cpio
 BuildRequires:  openscap openscap-utils openscap-python3
-BuildRequires:  anaconda >= 28.22
-Requires:       anaconda >= 28.22
+BuildRequires:  anaconda >= 30.14
+Requires:       anaconda >= 30.14
 Requires:       python3-cpio
 Requires:       openscap openscap-utils openscap-python3
 


### PR DESCRIPTION
Anaconda removes the install classes from the code. They are
replaced with cofiguration files.

**Depends on:** https://github.com/rhinstaller/anaconda/pull/1716