### PR TITLE
Remove outdated Makefile help usage and update development guide.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,6 @@ ZANATA_PULL_ARGS = --transdir po/
 ZANATA_PUSH_ARGS = --srcdir po/ --push-type source --force
 
 all:
-	@echo "usage: make dist"
-	@echo "       make test"
-	@echo "       make install"
-	@echo "       make uninstall"
 
 DISTNAME = $(NAME)-$(VERSION)
 ADDONDIR = /usr/share/anaconda/addons/

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -99,7 +99,32 @@ You can also debug Anaconda in a sophisticated way - as of 04/2018, switching to
 There is also an official https://fedoraproject.org/wiki/How_to_debug_installation_problems[how-to-debug documentation] though.
 
 
-== Running Unit Tests
+== Available make commands
+
+Following commands are available to be used in make command:
+
+----
+dist        - Build the release tarball
+install     - Install the plugin into your system
+uninstall   - Uninstall the plugin from your system
+po-pull     - Pull translations from Zanata
+potfile     - Update translation template file
+push-pot    - Push translation template to Zanata
+test        - Run pylint checks and unit tests
+pylint      - Run only pylint checks
+unittest    - Run only unit tests
+----
+
+=== Translations
+
+Following packages are needed to manage translations:
+
+----
+python2-zanata-client
+intltool
+----
+
+=== Running Unit Tests
 
 Following packages are needed to run unit tests:
 

--- a/po/Makefile
+++ b/po/Makefile
@@ -41,6 +41,7 @@ potfile: $(PYSRC) glade-po
 
 glade-po: $(GLADEFILES)
 	rm -rf tmp/
+	@which intltool-extract > /dev/null 2>&1 || echo "You may not have the intltool-extract installed, don't be surprised if the operation fails."
 	for f in $(GLADEFILES); do \
 		intltool-extract --type=gettext/glade -l $$f ;\
 	done


### PR DESCRIPTION
Update development guide with available Makefile commands.

Add a warning when intltool is not installed in the system similarly to the one for when Zanata is not installed either.