### PR TITLE
Remove translations from upstream CI 

### DIFF
--- a/oscap-anaconda-addon.spec
+++ b/oscap-anaconda-addon.spec
@@ -44,9 +44,8 @@ make unittest
 
 %install
 make install DESTDIR=%{buildroot}
-%find_lang %{name}
 
-%files -f %{name}.lang
+%files
 %{_datadir}/anaconda/addons/org_fedora_oscap
 
 %doc COPYING ChangeLog README.md


### PR DESCRIPTION
Pulling from Zanata every time there is a PR update is useless waste,
so tests for the upstream CI should be modified.

The run without pulling from Zanata takes 4 seconds, with pulling from Zanata it takes ~ 2 minutes and it creates traffic.

The rpmbuild is a part of CI, therefore we need to modify the spec file that is used.