### PR TITLE
Fixed the checksum function to use forward-compatible rb mode.

### DIFF
--- a/org_fedora_oscap/utils.py
+++ b/org_fedora_oscap/utils.py
@@ -175,8 +175,8 @@ def get_file_fingerprint(fpath, hash_obj):
 
     """
 
-    with open(fpath, "r") as fobj:
-        bsize = 4*1024
+    with open(fpath, "rb") as fobj:
+        bsize = 4 * 1024
         # process file as 4 KB blocks
         buf = fobj.read(bsize)
         while buf:

--- a/tests/data/file
+++ b/tests/data/file
@@ -1,0 +1,1 @@
+Test file to be hashed.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,6 +21,7 @@
 """Module with unit tests for the common.py module"""
 
 import mock
+import os
 from collections import namedtuple
 
 import pytest
@@ -143,3 +144,14 @@ def test_gen():
 
     # any better test for this?
     assert "next" in dir(mapped_generator)
+
+
+def test_hash():
+    file_hash = '87fcda7d9e7a22412e95779e2f8e70f929106c7b27a94f5f8510553ebf4624a6'
+    hash_obj = utils.get_hashing_algorithm(file_hash)
+    assert hash_obj.name == "sha256"
+
+    filepath = os.path.join(os.path.dirname(__file__), 'data', 'file')
+    computed_hash = utils.get_file_fingerprint(filepath, hash_obj)
+
+    assert file_hash == computed_hash


### PR DESCRIPTION
On python3, there is a problem as contents of `r`-opened file is string, but they are treated as bytes later. `rb` mode is fully python2-compatible.

Part of this PR is a test which was failing in the RHEL8 branch prior to the fix and now it passes.