### PR TITLE
Hack hub title to show translated.

### DIFF
--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -190,6 +190,8 @@ class OSCAPSpoke(NormalSpoke):
 
         NormalSpoke.__init__(self, data, storage, payload, instclass)
         self._addon_data = self.data.addons.org_fedora_oscap
+        # workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1673071
+        self.title = _(self.title)
         self._storage = storage
         self._ready = False
 


### PR DESCRIPTION
This is workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1673071

Currently, Anaconda tries to translate the plugin title, but being in different translation domain prevents it to succeed. This way, we provide already translated string.

Thanks @poncovka!