### PR TITLE
Improve the OAA UX.

### DIFF
--- a/org_fedora_oscap/gui/spokes/oscap.glade
+++ b/org_fedora_oscap/gui/spokes/oscap.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.22.2 -->
 <interface domain="oscap-anaconda-addon">
   <requires lib="gtk+" version="3.0"/>
   <requires lib="AnacondaWidgets" version="1.0"/>
@@ -97,8 +97,8 @@
                       <object class="GtkLabel" id="applyLabel">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">0.85000002384185791</property>
                         <property name="label" translatable="yes">Apply security policy:</property>
+                        <property name="xalign">0.85000002384185791</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -253,8 +253,8 @@
                           <object class="GtkLabel" id="chooseProfileLabel">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="xalign">0</property>
                             <property name="label" translatable="yes">Choose profile below:</property>
+                            <property name="xalign">0</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -267,6 +267,7 @@
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="shadow_type">in</property>
+                            <property name="min_content_height">160</property>
                             <child>
                               <object class="GtkTreeView" id="profilesView">
                                 <property name="visible">True</property>
@@ -340,8 +341,8 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="margin_top">20</property>
-                            <property name="xalign">0</property>
                             <property name="label" translatable="yes">Changes that were done or need to be done:</property>
+                            <property name="xalign">0</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -354,6 +355,7 @@
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="shadow_type">in</property>
+                            <property name="min_content_height">140</property>
                             <child>
                               <object class="GtkTreeView" id="changesView">
                                 <property name="visible">True</property>
@@ -444,9 +446,9 @@
                               <object class="GtkLabel" id="noContentLabel">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="xalign">0</property>
-                                <property name="label" translatable="no">No content found. Please enter data stream content or archive URL below:</property>
+                                <property name="label" translatable="yes">No content found. Please enter data stream content or archive URI below:</property>
                                 <property name="wrap">True</property>
+                                <property name="xalign">0</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>


### PR DESCRIPTION
- Set minimal height to profile view and to the changes view.
- ~Abbreviate profile descriptions to 4-9 lines based on total profile count.~ - see #113 

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1781790

Remarks: This PR can't be tested on Fedora, as liboscap depends on gconf2 that is not part of the installed system. Putting gconf2 into the Fedora update image breaks the system completely, likely because it needs post-install scriplets to perform important tasks. The only way to test is to use a RHEL8 installation s.a. `boot.img` in a subdirectory of http://10.43.136.2/trees/rhel-8-scratch-temp/
You may not be able to get content to the addon if #111 is not merged - content is not part of that boot image, and the installer update image of 19MB seems to be too big to get through.