### PR TITLE
Abbreviate profile descriptions based on total profile count

### DIFF
--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -154,6 +154,25 @@ def set_ready(func):
     return decorated
 
 
+def crop_to_n_lines(text, line_limit):
+    if line_limit < 2:
+        msg = (
+            "As cropping involves putting ellipsis on a separate line, "
+            "it doesn't make sense to crop to less than 2 lines.")
+        raise ValueError(msg)
+    lines = text.splitlines()
+    if len(lines) < line_limit:
+        return text
+    lines_to_keep = lines[:line_limit - 1]
+
+    if not lines_to_keep[-1].strip():
+        lines_to_keep[-1] = "..."
+    else:
+        lines_to_keep += ["..."]
+
+    return "\n".join(lines_to_keep)
+
+
 class OSCAPSpoke(NormalSpoke):
     """
     Main class of the OSCAP addon spoke that will appear in the Security
@@ -589,12 +608,26 @@ class OSCAPSpoke(NormalSpoke):
             # pylint: disable-msg=E1103
             profiles = self._content_handler.profiles
 
+        if len(profiles) > 9:
+            max_description_lines = 4
+        elif len(profiles) > 4:
+            max_description_lines = 6
+        else:
+            max_description_lines = 9
+
         for profile in profiles:
+            profile_is_active = True
+            description = profile.description
+
+            if profile.id != self._active_profile:
+                profile_is_active = False
+                description = crop_to_n_lines(description, max_description_lines)
+
             profile_markup = '<span weight="bold">%s</span>\n%s' \
-                                % (profile.title, profile.description)
+                                % (profile.title, description)
             self._profiles_store.append([profile.id,
                                          profile_markup,
-                                         profile.id == self._active_profile])
+                                         profile_is_active])
 
     def _add_message(self, message):
         """


### PR DESCRIPTION
Main problem with this PR:

- It is not easily possible to expand description of a profile that you would like to see.

The displayed text is set in `org_fedora_oscap/gui/spokes/oscap.py:626`, but it is not HTML, so a CSS/JS trick with a clickable "More" is not applicable. The text is specified in so-called [pango markup](https://developer.gnome.org/pygtk/stable/pango-markup-language.html) which can do nice tricks to fit a line to particular width, but it doesn't provide functionality to hide and expand long paragraphs.