### PR TITLE
Changed the spoke label back to uppercase.

### DIFF
--- a/org_fedora_oscap/gui/spokes/oscap.glade
+++ b/org_fedora_oscap/gui/spokes/oscap.glade
@@ -37,7 +37,7 @@
     <property name="can_focus">False</property>
     <property name="hexpand">True</property>
     <property name="vexpand">True</property>
-    <property name="window_name" translatable="yes">Security Policy</property>
+    <property name="window_name" translatable="yes">SECURITY POLICY</property>
     <signal name="button-clicked" handler="on_back_clicked" swapped="no"/>
     <child internal-child="main_box">
       <object class="GtkBox" id="AnacondaSpokeWindow-main_box1">

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -196,6 +196,9 @@ class OSCAPSpoke(NormalSpoke):
 
     # title of the spoke (will be displayed on the hub)
     title = N_("_Security Policy")
+    # The string "SECURITY POLICY" in oscap.glade is meant to be uppercase,
+    # as it is displayed inside the spoke as the spoke label,
+    # and spoke labels are all uppercase by a convention.
 
     # methods defined by API and helper methods #
     def __init__(self, data, storage, payload):


### PR DESCRIPTION
The spoke title which is defined in the Python code and visible in the hub should have capitalization that respects the local language convention.
However, the much less visible spoke label that is defined in the glade file should be uppercase, and so should be translations.

I have added a comment to the Python file, as the Glade file is machine-readable, and comments will be dropped if someone re-saves it.

See also: https://bugzilla.redhat.com/show_bug.cgi?id=1855041