### PR TITLE
avoiding UnicodeDecodeError in decode(), and output more errors

### DIFF
--- a/org_fedora_oscap/common.py
+++ b/org_fedora_oscap/common.py
@@ -136,8 +136,9 @@ class SubprocessLauncher(object):
 
         (stdout, stderr) = proc.communicate()
         self.stdout = stdout.decode()
-        self.stderr = stderr.decode()
+        self.stderr = stderr.decode(errors="replace")
         self.messages = re.findall(r'OpenSCAP Error:.*', self.stderr)
+        self.messages = self.messages + re.findall(r'E: oscap:.*', self.stderr)
 
         self.returncode = proc.returncode
 


### PR DESCRIPTION
Anaconda installer for RHEL8 failed in stderr.decode(), when oscap output the non-unicode characters in standard error.

Used profile: xccdf_org.ssgproject.content_profile_pci-dss
Related Rule: xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands

This rule outputs the file name containing unexpected characters into standard error.
Removing the file fixed the problem, but it shouldn't cause to terminate the entire installation process in the unexpected python error.

This fix is to avoid UnicodeDecodeError with errors="replace". I thought errors="ignore" was also good, but error='replace" is better to show any character existed in the file name.

Also, the following error was output from oscap command, but it's not captured in this addon.

E: oscap:     Unable to match regex pattern '[a-z]+' on string 'ThatG��s correct!.mp3', pcre_exec() returned error: -10.

It is better that this error is output it into anaconda.log as well. 

I tested this fix, and confirmed it worked.

I didn't touch self.stdout = stdout.decode(), since I didn't see any case that the similar problem happened in the standard output.