### PR TITLE
Update the language tooling from Zanata to Weblate for RHEL8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,14 @@ EXCLUDES = \
 	*~ \
 	*.pyc
 
-ZANATA_PULL_ARGS = --transdir po/
-ZANATA_PUSH_ARGS = --srcdir po/ --push-type source --force
+L10N_REPO_RELATIVE_PATH ?= OpenSCAP/oscap-anaconda-addon-l10n.git
+L10N_REPOSITORY ?= https://github.com/$(L10N_REPO_RELATIVE_PATH)
+L10N_REPOSITORY_RW ?= git@github.com:$(L10N_REPO_RELATIVE_PATH)
+# Branch used in anaconda-l10n repository.
+# This should be master all the time, unless you are testing translation PRs.
+GIT_L10N_BRANCH ?= master
+# The base branch, used to pair code with translations
+OAA_PARENT_BRANCH ?= rhel8-branch
 
 all:
 
@@ -73,13 +79,47 @@ dist:
 potfile:
 	$(MAKE) -C po potfile
 
-po-pull:
-	@which zanata > /dev/null 2>&1 || echo "You may not have the Zanata client installed, don't be surprised if the operation fails."
-	zanata pull $(ZANATA_PULL_ARGS)
+# po-pull and update-pot are "inspired" by corresponding Anaconda code at
+# https://github.com/rhinstaller/anaconda/blob/master/Makefile.am
+# Our use case is slightly simpler (only one pot file), but we don't use automake,
+# so there have to be some differences.
 
-push-pot: potfile
-	@which zanata > /dev/null 2>&1 || echo "You may not have the Zanata client installed, don't be surprised if the operation fails."
-	zanata push $(ZANATA_PUSH_ARGS)
+po-pull:
+	TEMP_DIR=$$(mktemp --tmpdir -d oscap-anaconda-addon-l10n-XXXXXXXXXX) && \
+	git clone --depth 1 -b $(GIT_L10N_BRANCH) -- $(L10N_REPOSITORY) $$TEMP_DIR && \
+	cp $$TEMP_DIR/$(OAA_PARENT_BRANCH)/*.po po/ && \
+	rm -rf $$TEMP_DIR
+
+# This algorithm will make these steps:
+# - clone localization repository
+# - copy pot file to this repository
+# - check if pot file is changed (ignore the POT-Creation-Date otherwise it's always changed)
+# - if not changed:
+#   - remove cloned repository
+# - if changed:
+#   - add pot file
+#   - commit pot file
+#   - tell user to verify this file and push to the remote from the temp dir
+POTFILE_BASENAME = oscap-anaconda-addon.pot
+update-pot:
+	$(MAKE) -C po potfile
+	TEMP_DIR=$$(mktemp --tmpdir -d oscap-anaconda-addon-l10n-XXXXXXXXXX) || exit 1 ; \
+	git clone --depth 1 -b $(GIT_L10N_BRANCH) -- $(L10N_REPOSITORY_RW) $$TEMP_DIR || exit 2 ; \
+	cp po/$(POTFILE_BASENAME) $$TEMP_DIR/$(OAA_PARENT_BRANCH)/ || exit 3 ; \
+	pushd $$TEMP_DIR/$(OAA_PARENT_BRANCH) ; \
+	git difftool --trust-exit-code -y -x "diff -u -I '^\"POT-Creation-Date: .*$$'" HEAD ./$(POTFILE_BASENAME) &>/dev/null ; \
+	if [ $$? -eq 0  ] ; then \
+		popd ; \
+		echo "Pot file is up to date" ; \
+		rm -rf $$TEMP_DIR ; \
+	else \
+		git add ./$(POTFILE_BASENAME) && \
+		git commit -m "Update $(POTFILE_BASENAME)" && \
+		popd && \
+		echo "Pot file updated for the localization repository $(L10N_REPOSITORY)" && \
+		echo "Please confirm changes (git diff HEAD~1) and push:" && \
+		echo "$$TEMP_DIR" ; \
+	fi ;
 
 install-po-files:
 	$(MAKE) -C po install RPM_BUILD_ROOT=$(DESTDIR)


### PR DESCRIPTION
Code is heavily based on contents of
https://github.com/rhinstaller/anaconda/blob/master/Makefile.am

Changes:

- Weblate is Github-based, so git and file operations are used instead of a CLI client.
- There is no push-pot, but update-pot, which leaves the latest step (git push) up to you.

Analogous PRs will have to be ported to other branches.