### PR TITLE
Expanded group data to detect more package collisions.

### DIFF
--- a/org_fedora_oscap/rule_handling.py
+++ b/org_fedora_oscap/rule_handling.py
@@ -40,12 +40,26 @@ from org_fedora_oscap.common import OSCAPaddonError, RuleMessage
 __all__ = ["RuleData"]
 
 
+# Mapping of packages to package environments and/or groups that depends on them
+# See also https://access.redhat.com/solutions/1201413 how to get group IDs.
+# on RHEL8, use e.g. grep -R "<id>" /var/cache/dnf/*
 ESSENTIAL_PACKAGES = {
     "xorg-x11-server-common": {
         "env": ["graphical-server-environment", "workstation-product-environment"],
+        "groups": ["workstation-product-environment"],
     },
     "nfs-utils": {
         "env": ["graphical-server-environment", "workstation-product-environment"],
+        "groups": ["workstation-product-environment"],
+    },
+    "tftp": {
+        "groups": ["network-server"],
+    },
+    "abrt": {
+        "groups": ["debugging"],
+    },
+    "gssproxy": {
+        "groups": ["file-server"],
     },
 }
 
@@ -642,7 +656,7 @@ class PackageRules(RuleHandler):
         if package_name in ksdata_packages.packageList:
             return True
         selected_install_env = ksdata_packages.environment
-        if selected_install_env in ESSENTIAL_PACKAGES[package_name].get("env"):
+        if selected_install_env in ESSENTIAL_PACKAGES[package_name].get("env", []):
             return True
         selected_install_groups_names = {g.name for g in ksdata_packages.groupList}
         for g in ESSENTIAL_PACKAGES[package_name].get("groups", []):


### PR DESCRIPTION
One can get list of groups using `dnf group list --hidden`, and then get contents of a group using `dnf group info <group name or ID>`.

This should cover RHEL8 OSPP and CIS profiles.

I can't understand how the `package_iprutils_removed` fits to the mix - `iprutils` are a mandatory part of the Core group (along e.g. Bash), so I would expect this rule to break every OSPP installation.