### PR TITLE
Allow to run tests in a container

### DIFF
--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -150,6 +150,12 @@ Run the unit tests using:
 make unittest
 ----
 
+Or install `podman` and run the tests in a container using:
+
+----
+make container-test
+----
+
 == Updating translations
 
 Sometimes it is neccessary to create a patch that updates translations present in the release tarball with custom translations, or translations from Zanata.

--- a/org_fedora_oscap/ks/oscap.py
+++ b/org_fedora_oscap/ks/oscap.py
@@ -403,6 +403,8 @@ class OSCAPdata(AddonData):
         :type ksdata: pykickstart.base.BaseHandler instance
 
         """
+        # FIXME: Delete the pylint comment below if possible.
+        # pylint: disable-msg=E1101
 
         if self.dry_run or not self.profile_id:
             # nothing more to be done in the dry-run mode or if no profile is
@@ -433,6 +435,7 @@ class OSCAPdata(AddonData):
                 else:
                     # Let's sleep forever to prevent any further actions and
                     # wait for the main thread to quit the process.
+                    # pylint: disable-msg=E1101
                     progressQ.send_quit(1)
                     while True:
                         time.sleep(100000)
@@ -461,6 +464,7 @@ class OSCAPdata(AddonData):
                 else:
                     # Let's sleep forever to prevent any further actions and
                     # wait for the main thread to quit the process.
+                    # pylint: disable-msg=E1101
                     progressQ.send_quit(1)
                     while True:
                         time.sleep(100000)
@@ -486,6 +490,7 @@ class OSCAPdata(AddonData):
             else:
                 # Let's sleep forever to prevent any further actions and wait
                 # for the main thread to quit the process.
+                # pylint: disable-msg=E1101
                 progressQ.send_quit(1)
                 while True:
                     time.sleep(100000)

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,18 @@
+FROM fedora:rawhide
+
+RUN dnf install -y \
+  make \
+  anaconda \
+  openscap-python3 \
+  python3-cpio \
+  python3-pycurl \
+  python3-pip \
+  && dnf clean all
+
+RUN pip install \
+  pylint \
+  pytest \
+  mock
+
+RUN mkdir /oscap-anaconda-addon
+WORKDIR /oscap-anaconda-addon

--- a/tests/test_ks_oscap.py
+++ b/tests/test_ks_oscap.py
@@ -312,11 +312,11 @@ def test_valid_fingerprints(blank_oscap_data):
 def test_invalid_fingerprints(blank_oscap_data):
     # invalid character
     with pytest.raises(
-            KickstartValueError, message="Unsupported or invalid fingerprint"):
+            KickstartValueError, match="Unsupported or invalid fingerprint"):
         blank_oscap_data.handle_line("fingerprint = %s?" % ("a" * 31))
 
     # invalid lengths (odd and even)
     for repetitions in (31, 41, 54, 66, 98, 124):
         with pytest.raises(
-                KickstartValueError, message="Unsupported fingerprint"):
+                KickstartValueError, match="Unsupported fingerprint"):
             blank_oscap_data.handle_line("fingerprint = %s" % ("a" * repetitions))


### PR DESCRIPTION
Use `make container-test` to run pylint checks and unit tests in a container.