### PR TITLE
Use the DBus API of the Kdump add-on

### DIFF
--- a/org_fedora_oscap/common.py
+++ b/org_fedora_oscap/common.py
@@ -37,7 +37,10 @@ import logging
 from collections import namedtuple
 import gettext
 from functools import wraps
+from dasbus.identifier import DBusServiceIdentifier
 from pyanaconda.core import constants
+from pyanaconda.core.dbus import DBus
+from pyanaconda.modules.common.constants.namespaces import ADDONS_NAMESPACE
 from pyanaconda.modules.common.constants.services import NETWORK
 from pyanaconda.threading import threadMgr, AnacondaThread
 from org_fedora_oscap import utils
@@ -87,6 +90,13 @@ SUPPORTED_ARCHIVES = (".zip", ".tar", ".tar.gz", ".tar.bz2", )
 
 # buffer size for reading and writing out data (in bytes)
 IO_BUF_SIZE = 2 * 1024 * 1024
+
+# DBus constants
+KDUMP = DBusServiceIdentifier(
+    namespace=ADDONS_NAMESPACE,
+    basename="Kdump",
+    message_bus=DBus
+)
 
 
 class OSCAPaddonError(Exception):

--- a/tests/test_rule_handling.py
+++ b/tests/test_rule_handling.py
@@ -3,7 +3,9 @@ import mock
 from collections import defaultdict
 
 from pyanaconda.modules.common.constants.objects import FIREWALL, DEVICE_TREE, BOOTLOADER
-from pyanaconda.modules.common.constants.services import NETWORK, STORAGE, USERS
+from pyanaconda.modules.common.constants.services import NETWORK, STORAGE, USERS, BOSS
+
+from org_fedora_oscap.common import KDUMP
 
 try:
     from org_fedora_oscap import rule_handling, common
@@ -137,6 +139,14 @@ def proxy_getter(monkeypatch):
 
 
 def set_dbus_defaults():
+    boss = BOSS.get_proxy()
+    boss.GetModules.return_value = [
+        KDUMP.service_name
+    ]
+
+    kdump = KDUMP.get_proxy()
+    kdump.KdumpEnabled = True
+
     network = NETWORK.get_proxy()
     network.Connected.return_value = True
 


### PR DESCRIPTION
Don't use kickstart data to work with the Kdump add-on. The data are not
available, because the add-on has been migrated on DBus. Use the DBus API
instead.

**Related to:** https://github.com/daveyoung/kdump-anaconda-addon/pull/29