### PR TITLE
Use the password policies from DBus

### DIFF
--- a/org_fedora_oscap/rule_handling.py
+++ b/org_fedora_oscap/rule_handling.py
@@ -28,11 +28,16 @@ import shlex
 import logging
 
 from pyanaconda.modules.common.util import is_module_available
-from pyanaconda.pwpolicy import F22_PwPolicyData
 from pyanaconda.core.constants import (
-    FIREWALL_ENABLED, FIREWALL_DISABLED, FIREWALL_USE_SYSTEM_DEFAULTS)
-from pyanaconda.modules.common.constants.objects import FIREWALL, BOOTLOADER, DEVICE_TREE
-from pyanaconda.modules.common.constants.services import NETWORK, STORAGE, USERS
+    FIREWALL_ENABLED, FIREWALL_DISABLED, FIREWALL_USE_SYSTEM_DEFAULTS,
+    PASSWORD_POLICY_ROOT
+    )
+from pyanaconda.modules.common.constants.objects import (
+    FIREWALL, BOOTLOADER, DEVICE_TREE,
+    USER_INTERFACE
+    )
+from pyanaconda.modules.common.constants.services import NETWORK, STORAGE, USERS, BOSS
+from pyanaconda.modules.common.structures.policy import PasswordPolicy
 
 from org_fedora_oscap import common
 from org_fedora_oscap.common import OSCAPaddonError, RuleMessage, KDUMP, get_packages_data, \
@@ -496,7 +501,6 @@ class PasswdRules(RuleHandler):
         """Constructor initializing attributes."""
 
         self._minlen = 0
-        self._created_policy = False
         self._orig_minlen = None
         self._orig_strict = None
 
@@ -552,37 +556,55 @@ class PasswdRules(RuleHandler):
             return ret
 
         # set the policy in any case (so that a weaker password is not entered)
-        pw_policy = ksdata.anaconda.pwpolicy.get_policy("root")
-        if pw_policy is None:
-            pw_policy = F22_PwPolicyData()
-            log.info("OSCAP addon: setting password policy %s" % pw_policy)
-            ksdata.anaconda.pwpolicy.policyList.append(pw_policy)
-            log.info("OSCAP addon: password policy list: %s" % ksdata.anaconda.pwpolicy.policyList)
-            self._created_policy = True
+        policies = self._get_password_policies()
+        policy = policies[PASSWORD_POLICY_ROOT]
 
-        self._orig_minlen = pw_policy.minlen
-        self._orig_strict = pw_policy.strict
-        pw_policy.minlen = self._minlen
-        pw_policy.strict = True
+        self._orig_minlen = policy.min_length
+        self._orig_strict = policy.is_strict
+        policy.min_length = self._minlen
+        policy.is_strict = True
 
+        self._set_password_policies(policies)
         return ret
 
     def revert_changes(self, ksdata, storage):
         """:see: RuleHander.revert_changes"""
+        policies = self._get_password_policies()
+        policy = policies[PASSWORD_POLICY_ROOT]
 
-        pw_policy = ksdata.anaconda.pwpolicy.get_policy("root")
-        if self._created_policy:
-            log.info("OSCAP addon: removing password policy: %s" % pw_policy)
-            ksdata.anaconda.pwpolicy.policyList.remove(pw_policy)
-            log.info("OSCAP addon: password policy list: %s" % ksdata.anaconda.pwpolicy.policyList)
-            self._created_policy = False
-        else:
-            if self._orig_minlen is not None:
-                pw_policy.minlen = self._orig_minlen
-                self._orig_minlen = None
-            if self._orig_strict is not None:
-                pw_policy.strict = self._orig_strict
-                self._orig_strict = None
+        if self._orig_minlen is not None:
+            policy.min_length = self._orig_minlen
+            self._orig_minlen = None
+        if self._orig_strict is not None:
+            policy.is_strict = self._orig_strict
+            self._orig_strict = None
+
+        self._set_password_policies(policies)
+
+    def _get_password_policies(self):
+        """Get the password policies from the installer.
+
+        :return: a dictionary of password policies
+        """
+        proxy = BOSS.get_proxy(USER_INTERFACE)
+        policies = PasswordPolicy.from_structure_dict(proxy.PasswordPolicies)
+
+        if PASSWORD_POLICY_ROOT not in policies:
+            policy = PasswordPolicy.from_defaults(PASSWORD_POLICY_ROOT)
+            policies[PASSWORD_POLICY_ROOT] = policy
+
+        return policies
+
+    def _set_password_policies(self, policies):
+        """Set the password policies for the installer.
+
+        :param policies: a dictionary of password policies
+        """
+        proxy = BOSS.get_proxy(USER_INTERFACE)
+
+        proxy.SetPasswordPolicies(
+            PasswordPolicy.to_structure_dict(policies)
+        )
 
 
 class PackageRules(RuleHandler):


### PR DESCRIPTION
Don't use the `%anaconda` section of the kickstart data. Use the DBus API instead.

**Depends on:** https://github.com/rhinstaller/anaconda/pull/3099