### PR TITLE
Fix issues with creating translations patches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ else
 	PYVERSION = -3
 endif
 
+TRANSLATIONS_DIR ?= po
+
 FILES = $(ADDON) \
 	$(TESTS) \
 	po \
@@ -87,7 +89,8 @@ potfile:
 po-pull:
 	TEMP_DIR=$$(mktemp --tmpdir -d oscap-anaconda-addon-l10n-XXXXXXXXXX) && \
 	git clone --depth 1 -b $(GIT_L10N_BRANCH) -- $(L10N_REPOSITORY) $$TEMP_DIR && \
-	cp $$TEMP_DIR/$(OAA_PARENT_BRANCH)/*.po po/ && \
+	mkdir -p $(TRANSLATIONS_DIR) && \
+	cp $$TEMP_DIR/$(OAA_PARENT_BRANCH)/*.po $(TRANSLATIONS_DIR)/ && \
 	rm -rf $$TEMP_DIR
 
 # This algorithm will make these steps:

--- a/tools/make-language-patch
+++ b/tools/make-language-patch
@@ -146,7 +146,7 @@ oaa_root="$(cd "$script_dir/.." && pwd)"
 
 # $1: Where to put those translations
 pull_translations_locally () {
-	(cd "$oaa_root" && make po-pull ZANATA_PULL_ARGS="--transdir $1")
+	(cd "$oaa_root" && make po-pull TRANSLATIONS_DIR="$1")
 }
 
 
@@ -195,7 +195,7 @@ mkdir -p "$destdir"
 if test -n "$_arg_local_content"; then
 	copy_translations_from_directory "$_arg_local_content" "$destdir"
 else
-	pull_translations_locally "$tmpdir/a/po"
+	pull_translations_locally "$destdir"
 fi
 
 cp "$oaa_root/po/Makefile" "$oaa_root/po/oscap-anaconda-addon.pot" "$destdir"


### PR DESCRIPTION
- Pull translations to the po directory by default (Makefile).
- Fix translation pull destination (tools/make-language-patch)