### PR TITLE
Add packages

### DIFF
--- a/create_update_image.sh
+++ b/create_update_image.sh
@@ -179,6 +179,8 @@ packages="
 	python3-cpio
 	python3-pycurl
 	oscap-anaconda-addon
+	xmlsec1
+	xmlsec1-openssl
 "
 
 


### PR DESCRIPTION
Starting from OpenSCAP 1.3.5, OpenSCAP depends on xmlsec1 library.
Therefore, OAA needs to have these packages present in the update
img.
.#