### PR TITLE
Raise error when file not on the server or there is another error

### DIFF
--- a/org_fedora_oscap/common.py
+++ b/org_fedora_oscap/common.py
@@ -38,10 +38,7 @@ from collections import namedtuple
 import gettext
 from functools import wraps
 from pyanaconda.core import constants
-from pyanaconda.modules.common.constants.services import NETWORK
-from pyanaconda.threading import threadMgr, AnacondaThread
 from org_fedora_oscap import utils
-from org_fedora_oscap.data_fetch import fetch_data
 
 log = logging.getLogger("anaconda")
 
@@ -59,7 +56,7 @@ def N_(string): return string
 
 # everything else should be private
 __all__ = ["run_oscap_remediate", "get_fix_rules_pre",
-           "wait_and_fetch_net_data", "extract_data", "strip_content_dir",
+           "extract_data", "strip_content_dir",
            "OSCAPaddonError"]
 
 INSTALLATION_CONTENT_DIR = "/tmp/openscap_data/"
@@ -276,38 +273,6 @@ def run_oscap_remediate(profile, fpath, ds_id="", xccdf_id="", tailoring="",
         raise OSCAPaddonError(msg)
 
     return proc.stdout
-
-
-def wait_and_fetch_net_data(url, out_file, ca_certs=None):
-    """
-    Function that waits for network connection and starts a thread that fetches
-    data over network.
-
-    :see: org_fedora_oscap.data_fetch.fetch_data
-    :return: the name of the thread running fetch_data
-    :rtype: str
-
-    """
-
-    # get thread that tries to establish a network connection
-    nm_conn_thread = threadMgr.get(constants.THREAD_WAIT_FOR_CONNECTING_NM)
-    if nm_conn_thread:
-        # NM still connecting, wait for it to finish
-        nm_conn_thread.join()
-
-    network_proxy = NETWORK.get_proxy()
-    if not network_proxy.Connected:
-        raise OSCAPaddonNetworkError("Network connection needed to fetch data.")
-
-    fetch_data_thread = AnacondaThread(name=THREAD_FETCH_DATA,
-                                       target=fetch_data,
-                                       args=(url, out_file, ca_certs),
-                                       fatal=False)
-
-    # register and run the thread
-    threadMgr.add(fetch_data_thread)
-
-    return THREAD_FETCH_DATA
 
 
 def extract_data(archive, out_dir, ensure_has_files=None):

--- a/org_fedora_oscap/data_fetch.py
+++ b/org_fedora_oscap/data_fetch.py
@@ -11,6 +11,7 @@ import pycurl
 
 from pyanaconda.core.configuration.anaconda import conf
 
+from org_fedora_oscap.common import _
 from org_fedora_oscap import utils
 
 import logging
@@ -195,4 +196,10 @@ def _curl_fetch(url, out_file, ca_certs=None):
             raise CertificateValidationError(msg)
         else:
             msg = "Failed to fetch data: %s" % err
+            raise FetchError(msg)
+
+    if protocol in ("http", "https"):
+        return_code = curl.getinfo(pycurl.HTTP_CODE)
+        if 400 <= return_code < 600:
+            msg = _(f"Failed to fetch data - the request returned HTTP error code {return_code}")
             raise FetchError(msg)

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -354,10 +354,10 @@ class OSCAPSpoke(NormalSpoke):
                for net_prefix in data_fetch.NET_URL_PREFIXES):
             # need to fetch data over network
             try:
-                thread_name = common.wait_and_fetch_net_data(
-                                     self._addon_data.content_url,
-                                     self._addon_data.raw_preinst_content_path,
-                                     self._addon_data.certificates)
+                thread_name = data_fetch.wait_and_fetch_net_data(
+                     self._addon_data.content_url,
+                     self._addon_data.raw_preinst_content_path,
+                     self._addon_data.certificates)
             except common.OSCAPaddonNetworkError:
                 self._network_problem()
                 with self._fetch_flag_lock:

--- a/tests/test_data_fetch.py
+++ b/tests/test_data_fetch.py
@@ -6,6 +6,8 @@ import sys
 import subprocess
 import time
 
+import pytest
+
 from org_fedora_oscap import data_fetch
 
 
@@ -38,6 +40,16 @@ def test_file_retreival():
             "http://localhost:{}/{}".format(PORT, relative_filename_to_test), temp_filename)
 
     assert filecmp.cmp(relative_filename_to_test, temp_filename)
+
+
+def test_file_absent():
+    relative_filename_to_test = "i_am_not_here.file"
+
+    with serve_directory_in_separate_process(PORT):
+        with pytest.raises(data_fetch.FetchError) as exc:
+            data_fetch._curl_fetch(
+                "http://localhost:{}/{}".format(PORT, relative_filename_to_test), "/dev/null")
+            assert "error code 404" in str(exc)
 
 
 def test_supported_url():


### PR DESCRIPTION
Previously, the error would be raised when the other code would try to work with the retrieved file that in fact doesn't exist. Now, the error is identified on time, and it can be communicated properly as the installation feedback.