### PR TITLE
Import mock from unittest, where it has been relocated

### DIFF
--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -21,7 +21,7 @@
 """Module with unit tests for the common.py module"""
 
 import os
-import mock
+from unittest import mock
 import shutil
 
 import pytest

--- a/tests/test_rule_handling.py
+++ b/tests/test_rule_handling.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 from collections import defaultdict
 
 from pyanaconda.modules.common.constants.objects import FIREWALL, DEVICE_TREE, BOOTLOADER

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,9 +18,8 @@
 # Red Hat Author(s): Vratislav Podzimek <vpodzime@redhat.com>
 #
 
-"""Module with unit tests for the common.py module"""
 
-import mock
+from unittest import mock
 import os
 from collections import namedtuple
 


### PR DESCRIPTION
The separate Python mock package has been deprecated as a result of the mock inclusion into the standard library.