### PR TITLE
Various RHEL9 improvements

### DIFF
--- a/org_fedora_oscap/common.py
+++ b/org_fedora_oscap/common.py
@@ -564,7 +564,7 @@ def get_content_name(data):
 def get_raw_preinst_content_path(data):
     """Path to the raw (unextracted, ...) pre-installation content file"""
     if data.content_type == "scap-security-guide":
-        log.debug("Using scap-security-guide, no single content file")
+        log.debug("OSCAP addon: Using scap-security-guide, no single content file")
         return None
 
     content_name = get_content_name(data)
@@ -667,7 +667,7 @@ def set_packages_data(data: PackagesConfigurationData):
     payload_proxy = get_payload_proxy()
 
     if payload_proxy.Type != PAYLOAD_TYPE_DNF:
-        log.debug("The payload doesn't support packages.")
+        log.debug("OSCAP addon: The payload doesn't support packages.")
         return
 
     return payload_proxy.SetPackages(

--- a/org_fedora_oscap/content_handling.py
+++ b/org_fedora_oscap/content_handling.py
@@ -111,9 +111,8 @@ ContentFiles = namedtuple("ContentFiles", ["xccdf", "cpe", "tailoring"])
 
 
 def identify_files(fpaths):
-    with multiprocessing.Pool(os.cpu_count()) as p:
-        labels = p.map(get_doc_type, fpaths)
-    return {path: label for (path, label) in zip(fpaths, labels)}
+    result = {path: get_doc_type(path) for path in fpaths}
+    return result
 
 
 def get_doc_type(file_path):
@@ -131,7 +130,9 @@ def get_doc_type(file_path):
     except UnicodeDecodeError:
         # 'oscap info' supplied weird output, which happens when it tries
         # to explain why it can't examine e.g. a JPG.
-        return None
+        pass
+    except Exception as e:
+        log.warning(f"OSCAP addon: Unexpected error when looking at {file_path}: {str(e)}")
     log.info("OSCAP addon: Identified {file_path} as {content_type}"
              .format(file_path=file_path, content_type=content_type))
     return content_type

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -331,6 +331,7 @@ class OSCAPSpoke(NormalSpoke):
 
         # if no content was specified and SSG is available, use it
         if not self._policy_data.content_type and common.ssg_available():
+            log.info("OSCAP Addon: Defaulting to local content")
             self._policy_data.content_type = "scap-security-guide"
             self._policy_data.content_path = common.SSG_DIR + common.SSG_CONTENT
 
@@ -351,7 +352,7 @@ class OSCAPSpoke(NormalSpoke):
             self._fetch_data_and_initialize()
 
     def _handle_error(self, exception):
-        log.error(str(exception))
+        log.error("OSCAP Addon: " + str(exception))
         if isinstance(exception, KickstartValueError):
             self._invalid_url()
         elif isinstance(exception, common.OSCAPaddonNetworkError):
@@ -365,7 +366,7 @@ class OSCAPSpoke(NormalSpoke):
         elif isinstance(exception, content_handling.ContentCheckError):
             self._integrity_check_failed()
         else:
-            log.exception("Unknown exception occurred", exc_info=exception)
+            log.exception("OSCAP Addon: Unknown exception occurred", exc_info=exception)
             self._general_content_problem()
 
     def _render_selected(self, column, renderer, model, itr, user_data=None):
@@ -385,6 +386,7 @@ class OSCAPSpoke(NormalSpoke):
 
         thread_name = None
         if self._policy_data.content_url and self._policy_data.content_type != "scap-security-guide":
+            log.info(f"OSCAP Addon: Actually fetching content from somewhere")
             thread_name = self.content_bringer.fetch_content(
                 self._handle_error, self._policy_data.certificates)
 
@@ -442,7 +444,7 @@ class OSCAPSpoke(NormalSpoke):
                 msg += f" with tailoring {preinst_tailoring_path}"
             else:
                 msg += " without considering tailoring"
-            log.info(msg)
+            log.info("OSCAP Addon: " + msg)
 
             self._content_handler = scap_content_handler.SCAPContentHandler(
                 preinst_content_path,
@@ -456,7 +458,7 @@ class OSCAPSpoke(NormalSpoke):
 
             return
 
-        log.info("OAA: Done with analysis")
+        log.info("OSCAP Addon: Done with analysis")
 
         self._ds_checklists = self._content_handler.get_data_streams_checklists()
         if self._using_ds:
@@ -592,7 +594,7 @@ class OSCAPSpoke(NormalSpoke):
         try:
             profiles = self._content_handler.get_profiles()
         except scap_content_handler.SCAPContentHandlerError as e:
-            log.warning(str(e))
+            log.warning("OSCAP Addon: " + str(e))
             self._invalid_content()
 
         for profile in profiles:
@@ -736,7 +738,7 @@ class OSCAPSpoke(NormalSpoke):
                 ds, xccdf, common.get_preinst_tailoring_path(self._policy_data))
         except common.OSCAPaddonError as exc:
             log.error(
-                "Failed to get rules for the profile '{}': {}"
+                "OSCAP Addon: Failed to get rules for the profile '{}': {}"
                 .format(profile_id, str(exc)))
             self._set_error(
                 "Failed to get rules for the profile '{}'"
@@ -908,6 +910,7 @@ class OSCAPSpoke(NormalSpoke):
     def _refresh_ui(self):
         """Refresh the UI elements."""
         if not self._content_defined:
+            log.info("OSCAP Addon: Content not defined")
             # hide the control buttons
             really_hide(self._control_buttons)
 
@@ -1156,7 +1159,9 @@ class OSCAPSpoke(NormalSpoke):
         with self._fetch_flag_lock:
             if self._fetching:
                 # some other fetching/pre-processing running, give up
-                log.warn("Clicked the fetch button, although the GUI is in the fetching mode.")
+                log.warn(
+                    "OSCAP Addon: "
+                    "Clicked the fetch button, although the GUI is in the fetching mode.")
                 return
 
         # prevent user from changing the URL in the meantime

--- a/org_fedora_oscap/rule_handling.py
+++ b/org_fedora_oscap/rule_handling.py
@@ -261,7 +261,7 @@ class RuleData(RuleHandler):
         try:
             actions[first_word](rule)
         except (ModifiedOptionParserException, KeyError) as e:
-            log.warning("Unknown OSCAP Addon rule '{}': {}".format(rule, e))
+            log.warning("OSCAP Addon: Unknown OSCAP Addon rule '{}': {}".format(rule, e))
 
     def eval_rules(self, ksdata, storage, report_only=False):
         """:see: RuleHandler.eval_rules"""
@@ -565,7 +565,7 @@ class PasswdRules(RuleHandler):
             # root password set
             if users_proxy.IsRootPasswordCrypted:
                 msg = _("cannot check root password length (password is crypted)")
-                log.warning("cannot check root password length (password is crypted)")
+                log.warning("OSCAP Addon: cannot check root password length (password is crypted)")
                 return [RuleMessage(self.__class__,
                                     common.MESSAGE_TYPE_WARNING, msg)]
             elif len(users_proxy.RootPassword) < self._minlen:
@@ -880,7 +880,7 @@ class KdumpRules(RuleHandler):
 
                 kdump_proxy.KdumpEnabled = self._kdump_enabled
             else:
-                log.warning("com_redhat_kdump is not installed. "
+                log.warning("OSCAP Addon: com_redhat_kdump is not installed. "
                             "Skipping kdump configuration")
 
         return messages
@@ -894,7 +894,7 @@ class KdumpRules(RuleHandler):
             if self._kdump_enabled is not None:
                 kdump_proxy.KdumpEnabled = self._kdump_default_enabled
         else:
-            log.warning("com_redhat_kdump is not installed. "
+            log.warning("OSCAP Addon: com_redhat_kdump is not installed. "
                         "Skipping reverting kdump configuration")
 
         self._kdump_enabled = None

--- a/org_fedora_oscap/service/installation.py
+++ b/org_fedora_oscap/service/installation.py
@@ -28,14 +28,14 @@ from org_fedora_oscap.common import _, get_packages_data, set_packages_data
 from org_fedora_oscap.content_handling import ContentCheckError
 from org_fedora_oscap import content_discovery
 
-log = logging.getLogger(__name__)
+log = logging.getLogger("anaconda")
 
 
 REQUIRED_PACKAGES = ("openscap", "openscap-scanner",)
 
 
 def _handle_error(exception):
-    log.error("Failed to fetch and initialize SCAP content!")
+    log.error("OSCAP Addon: Failed to fetch and initialize SCAP content!")
 
     if isinstance(exception, ContentCheckError):
         msg = _("The integrity check of the security content failed.")
@@ -87,7 +87,7 @@ class PrepareValidContent(Task):
 
         content = self.content_bringer.finish_content_fetch(
             fetching_thread_name, self._policy_data.fingerprint,
-            lambda msg: log.info(msg), content_dest, _handle_error)
+            lambda msg: log.info("OSCAP Addon: " + msg), content_dest, _handle_error)
 
         if not content:
             # this shouldn't happen because error handling is supposed to

--- a/org_fedora_oscap/service/kickstart.py
+++ b/org_fedora_oscap/service/kickstart.py
@@ -25,7 +25,7 @@ from pykickstart.errors import KickstartValueError, KickstartParseError
 from org_fedora_oscap import common, utils
 from org_fedora_oscap.structures import PolicyData
 
-log = logging.getLogger(__name__)
+log = logging.getLogger("anaconda")
 
 __all__ = ["OSCAPKickstartSpecification"]
 

--- a/org_fedora_oscap/service/oscap.py
+++ b/org_fedora_oscap/service/oscap.py
@@ -34,7 +34,7 @@ from org_fedora_oscap.service.kickstart import OSCAPKickstartSpecification, Kick
 from org_fedora_oscap.service.oscap_interface import OSCAPInterface
 from org_fedora_oscap.structures import PolicyData
 
-log = logging.getLogger(__name__)
+log = logging.getLogger("anaconda")
 
 __all__ = ["OSCAPService"]
 
@@ -71,7 +71,7 @@ class OSCAPService(KickstartService):
         """
         self._policy_enabled = value
         self.policy_enabled_changed.emit()
-        log.debug("Policy enabled is set to '%s'.", value)
+        log.debug("OSCAP Addon: Policy enabled is set to '%s'.", value)
 
     @property
     def policy_data(self):
@@ -89,7 +89,7 @@ class OSCAPService(KickstartService):
         """
         self._policy_data = value
         self.policy_data_changed.emit()
-        log.debug("Policy data is set to '%s'.", value)
+        log.debug("OSCAP Addon: Policy data is set to '%s'.", value)
 
     @property
     def installation_enabled(self):
@@ -150,7 +150,7 @@ class OSCAPService(KickstartService):
         :return: a list of requirements
         """
         if not self.installation_enabled:
-            log.debug("The installation is disabled. Skip the requirements.")
+            log.debug("OSCAP Addon: The installation is disabled. Skip the requirements.")
             return []
 
         requirements = [
@@ -180,7 +180,7 @@ class OSCAPService(KickstartService):
         :return: a list of tasks
         """
         if not self.installation_enabled:
-            log.debug("The installation is disabled. Skip the configuration.")
+            log.debug("OSCAP Addon: The installation is disabled. Skip the configuration.")
             return []
 
         tasks = [
@@ -205,7 +205,7 @@ class OSCAPService(KickstartService):
         :return: a list of tasks
         """
         if not self.installation_enabled:
-            log.debug("The installation is disabled. Skip the installation.")
+            log.debug("OSCAP Addon: The installation is disabled. Skip the installation.")
             return []
 
         tasks = [


### PR DESCRIPTION
Make all log entries identifiable easily - use the `anaconda` logger, so they are logged to the Anaconda log, and they can be grepped.

Then, fix handling of the local content when its usage is triggered by the button on the content fetch page.

Finally, remove the multiprocessing pool when evaluating files - it causes https://bugzilla.redhat.com/show_bug.cgi?id=1989434