### PR TITLE
Fix archive handling in GUI installs

### DIFF
--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -196,7 +196,8 @@ class ContentBringer:
             if not dest_filename:  # using scap-security-guide
                 fpaths = [self.DEFAULT_SSG_DATA_STREAM_PATH]
             else:  # Using downloaded XCCDF/OVAL/DS/tailoring
-                fpaths = glob(str(self.CONTENT_DOWNLOAD_LOCATION / "*.xml"))
+                fpaths = pathlib.Path(self.CONTENT_DOWNLOAD_LOCATION).rglob("*")
+                fpaths = [str(p) for p in fpaths if p.is_file()]
         else:
             dest_filename = pathlib.Path(dest_filename)
             # RPM is an archive at this phase

--- a/org_fedora_oscap/ks/oscap.py
+++ b/org_fedora_oscap/ks/oscap.py
@@ -393,7 +393,7 @@ class OSCAPdata(AddonData):
                 time.sleep(100000)
 
     def _handle_error(self, exception):
-        log.error("Failed to fetch and initialize SCAP content!")
+        log.error(f"Failed to fetch and initialize SCAP content: {str(exception)}")
 
         if isinstance(exception, ContentCheckError):
             msg = _("The integrity check of the security content failed.")


### PR DESCRIPTION
GUI downloads an archive, so the ensuing installation doesn't have to.
However, the installation has to be able to discover files recovered from the archive.
The fix makes sure that files are discovered also in subdirectories.