### PR TITLE
Don't show the OSCAP spoke if the OSCAP DBus module is disabled

### DIFF
--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -36,6 +36,7 @@ from org_fedora_oscap.constants import OSCAP
 from org_fedora_oscap.structures import PolicyData
 
 from pyanaconda.modules.common.constants.services import USERS
+from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.communication import hubQ
@@ -202,6 +203,10 @@ class OSCAPSpoke(NormalSpoke):
     # The string "SECURITY PROFILE" in oscap.glade is meant to be uppercase,
     # as it is displayed inside the spoke as the spoke label,
     # and spoke labels are all uppercase by a convention.
+
+    @classmethod
+    def should_run(cls, environment, data):
+        return is_module_available(OSCAP)
 
     # methods defined by API and helper methods #
     def __init__(self, data, storage, payload):


### PR DESCRIPTION
Add-ons can be disabled in the Anaconda configuration files. Without the fix,
the OSCAP DBus module is started on demand by the OSCAP spoke even though it
shouldn't be activated. In the future, it will result in a failure of the
installer.

Related: rhbz#1994003