### PR TITLE
Fix import of the PackagesSelectionData class

### DIFF
--- a/org_fedora_oscap/common.py
+++ b/org_fedora_oscap/common.py
@@ -43,7 +43,7 @@ from pyanaconda.core.dbus import DBus
 from pyanaconda.core.constants import PAYLOAD_TYPE_DNF
 from pyanaconda.modules.common.constants.namespaces import ADDONS_NAMESPACE
 from pyanaconda.modules.common.constants.services import NETWORK, PAYLOADS
-from pyanaconda.modules.common.structures.payload import PackagesSelectionData
+from pyanaconda.modules.common.structures.packages import PackagesSelectionData
 from pyanaconda.threading import threadMgr, AnacondaThread
 from org_fedora_oscap import utils
 from org_fedora_oscap.data_fetch import fetch_data


### PR DESCRIPTION
The class is provided by `pyanaconda.modules.common.structures.packages`.