### PR TITLE
Allow to create an update image in a container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,10 @@ container-test:
 	podman build --tag $(CONTAINER_NAME) --file tests/Dockerfile
 	podman run --volume .:/oscap-anaconda-addon:Z $(CONTAINER_NAME) make test
 
+container-update-image:
+	podman build --tag $(CONTAINER_NAME) --file tests/Dockerfile
+	podman run --volume .:/oscap-anaconda-addon:Z $(CONTAINER_NAME) ./create_update_image.sh -r / download_rpms
+
 test: unittest runpylint
 
 runpylint:

--- a/create_update_image.sh
+++ b/create_update_image.sh
@@ -56,7 +56,7 @@ _arg_start_with="install_rpms"
 _arg_languages="off"
 _arg_rpm_dir="$build_dir/rpm"
 _arg_tmp_root="$(mktemp -d)"
-_arg_releasever="28"
+_arg_releasever="rawhide"
 
 
 print_help()
@@ -66,7 +66,7 @@ print_help()
 	printf '\t%s\n' "-l, --languages, --no-languages: Include languages in the image. The increased image size may cause problems. (off by default)"
 	printf '\t%s\n' "--rpm-dir: Where to put/take from RPMs to install (default: '$build_dir/rpm')"
 	printf '\t%s\n' "--tmp-root: Fake temp root (default: '$(mktemp -d)')"
-	printf '\t%s\n' "-r, --releasever: Version of the target OS (default: '28')"
+	printf '\t%s\n' "-r, --releasever: Version of the target OS (default: 'rawhide')"
 	printf '\t%s\n' "-h, --help: Prints help"
 }
 

--- a/create_update_image.sh
+++ b/create_update_image.sh
@@ -178,6 +178,7 @@ packages="
 	openscap-scanner
 	python3-cpio
 	python3-pycurl
+	xmlsec1-openssl
 	oscap-anaconda-addon
 	xmlsec1
 	xmlsec1-openssl

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -38,6 +38,12 @@ For further reading, see the https://fedoraproject.org/wiki/Anaconda/Updates#How
 ./create_update_image.sh download_rpms
 ----
 
+Or install `podman` and create the update image with dependencies in a container using:
+
+----
+make container-update-image
+----
+
 If you want to see what was packed, you can extract the image.
 
 ----

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,6 +1,8 @@
-FROM fedora:rawhide
+FROM registry.fedoraproject.org/fedora:rawhide
 
-RUN dnf install -y \
+RUN dnf update -y \
+  ; dnf install -y \
+  'dnf-command(download)' \
   make \
   anaconda \
   openscap \
@@ -10,7 +12,7 @@ RUN dnf install -y \
   python3-cpio \
   python3-pycurl \
   python3-pip \
-  && dnf clean all
+  ; dnf clean all
 
 RUN pip install \
   pylint \


### PR DESCRIPTION
Run `make container-update-image` to create an update image of the OSCAP
addon and its main dependencies in a container.

Download and install the `xmlsec1-openssl` dependency for the upstream testing.