### PR TITLE
Use the unified help support

### DIFF
--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -185,9 +185,6 @@ class OSCAPSpoke(NormalSpoke):
     # name of the .glade file in the same directory as this source
     uiFile = "oscap.glade"
 
-    # id of the help content for this spoke
-    help_id = "SecurityPolicySpoke"
-
     # domain of oscap-anaconda-addon translations
     translationDomain = "oscap-anaconda-addon"
 

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -204,6 +204,11 @@ class OSCAPSpoke(NormalSpoke):
     # as it is displayed inside the spoke as the spoke label,
     # and spoke labels are all uppercase by a convention.
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "security-policy-selection"
+
     @classmethod
     def should_run(cls, environment, data):
         return is_module_available(OSCAP)


### PR DESCRIPTION
Anaconda is going to use a screen id to find the related help content.

**Related:** https://github.com/rhinstaller/anaconda/pull/3575