### PR TITLE
Fix bad destination for the parsed content fingerprint

### DIFF
--- a/org_fedora_oscap/service/kickstart.py
+++ b/org_fedora_oscap/service/kickstart.py
@@ -140,7 +140,7 @@ class OSCAPKickstartData(AddonData):
             msg = "Unsupported fingerprint"
             raise KickstartValueError(msg)
 
-        self.fingerprint = value
+        self.policy_data.fingerprint = value
 
     def _parse_certificates(self, value):
         self.policy_data.certificates = value


### PR DESCRIPTION
Using the old ways, the fingerprint was not propagated to the post-install kickstart.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1993065