### PR TITLE
Use the PackagesSelection property

### DIFF
--- a/org_fedora_oscap/common.py
+++ b/org_fedora_oscap/common.py
@@ -652,7 +652,7 @@ def get_packages_data() -> PackagesSelectionData:
         return PackagesSelectionData()
 
     return PackagesSelectionData.from_structure(
-        payload_proxy.Packages
+        payload_proxy.PackagesSelection
     )
 
 
@@ -667,6 +667,6 @@ def set_packages_data(data: PackagesSelectionData):
         log.debug("The payload doesn't support packages.")
         return
 
-    return payload_proxy.SetPackages(
+    return payload_proxy.SetPackagesSelection(
         PackagesSelectionData.to_structure(data)
     )

--- a/tests/test_rule_handling.py
+++ b/tests/test_rule_handling.py
@@ -177,7 +177,7 @@ def set_dbus_defaults():
     dnf_payload.Type = PAYLOAD_TYPE_DNF
 
     packages_data = PackagesConfigurationData()
-    dnf_payload.Packages = PackagesConfigurationData.to_structure(packages_data)
+    dnf_payload.PackagesSelection = PackagesConfigurationData.to_structure(packages_data)
 
 
 def test_evaluation_existing_part_must_exist_rules(
@@ -596,7 +596,7 @@ def test_evaluation_package_rules(proxy_getter, rule_data, ksdata_mock, storage_
     packages_data.packages = ["vim"]
 
     dnf_payload_mock = PAYLOADS.get_proxy("/fake/payload/1")
-    dnf_payload_mock.Packages = PackagesConfigurationData.to_structure(packages_data)
+    dnf_payload_mock.PackagesSelection = PackagesConfigurationData.to_structure(packages_data)
 
     messages = rule_data.eval_rules(ksdata_mock, storage_mock)
 
@@ -615,7 +615,7 @@ def test_evaluation_package_rules(proxy_getter, rule_data, ksdata_mock, storage_
     packages_data.packages = ["vim", "firewalld", "iptables"]
     packages_data.excluded_packages = ["telnet"]
 
-    dnf_payload_mock.SetPackages.assert_called_once_with(
+    dnf_payload_mock.SetPackagesSelection.assert_called_once_with(
         PackagesConfigurationData.to_structure(packages_data)
     )
 
@@ -638,7 +638,7 @@ def test_evaluation_package_rules_report_only(proxy_getter, rule_data, ksdata_mo
 
     # report_only --> no packages should be added or excluded
     dnf_payload_mock = PAYLOADS.get_proxy("/fake/payload/1")
-    dnf_payload_mock.SetPackages.assert_not_called()
+    dnf_payload_mock.SetPackagesSelection.assert_not_called()
 
 
 def test_evaluation_bootloader_passwd_not_set(proxy_getter, rule_data, ksdata_mock, storage_mock):
@@ -761,12 +761,12 @@ def test_revert_package_rules(proxy_getter, rule_data, ksdata_mock, storage_mock
     packages_data.packages = ["vim"]
 
     dnf_payload_mock = PAYLOADS.get_proxy("/fake/payload/1")
-    dnf_payload_mock.Packages = PackagesConfigurationData.to_structure(packages_data)
+    dnf_payload_mock.PackagesSelection = PackagesConfigurationData.to_structure(packages_data)
 
     def set_packages(structure):
-        dnf_payload_mock.Packages = structure
+        dnf_payload_mock.PackagesSelection = structure
 
-    dnf_payload_mock.SetPackages.side_effect = set_packages
+    dnf_payload_mock.SetPackagesSelection.side_effect = set_packages
 
     # run twice --> nothing should be different in the second run
     messages = rule_data.eval_rules(ksdata_mock, storage_mock)
@@ -779,7 +779,7 @@ def test_revert_package_rules(proxy_getter, rule_data, ksdata_mock, storage_mock
 
     # (only) added and excluded packages should have been removed from the
     # list
-    dnf_payload_mock.SetPackages.assert_called_with(
+    dnf_payload_mock.SetPackagesSelection.assert_called_with(
         PackagesConfigurationData.to_structure(packages_data)
     )
 
@@ -793,6 +793,6 @@ def test_revert_package_rules(proxy_getter, rule_data, ksdata_mock, storage_mock
 
     # (only) added and excluded packages should have been removed from the
     # list
-    dnf_payload_mock.SetPackages.assert_called_with(
+    dnf_payload_mock.SetPackagesSelection.assert_called_with(
         PackagesConfigurationData.to_structure(packages_data)
     )


### PR DESCRIPTION
The `Packages` property no longer exists. It was replaced with `PackagesSelection` and
`PackagesConfiguration` properties. This bug was introduced in the commit 2014f1e.