### PR TITLE
Fix tailoring

### DIFF
--- a/org_fedora_oscap/service/oscap.py
+++ b/org_fedora_oscap/service/oscap.py
@@ -221,7 +221,7 @@ class OSCAPService(KickstartService):
                 sysroot=conf.target.system_root,
                 policy_data=self.policy_data,
                 target_content_path=common.get_postinst_content_path(self.policy_data),
-                target_tailoring_path=common.get_preinst_tailoring_path(self.policy_data)
+                target_tailoring_path=common.get_postinst_tailoring_path(self.policy_data)
             )
         ]
 


### PR DESCRIPTION
Fixes an error during installation caused during tailoring

Addressing:
dasbus.error.DBusError: Content evaluation and remediation with the oscap tool failed: OpenSCAP Error: Unable to open file: '/tmp/openscap_data/usr/share/xml/scap/sc_tailoring/tailoring-xccdf.xml' [/builddir/build/BUILD/openscap-1.3.5/src/source/oscap_source.c:288]

This is proabably a typo coming from 87509fb6ee22b6eeaa66ea4ae85ebf5abd353e14
which is only in rhel9-branch.