### PR TITLE
Improve UX when there are weird errors when attempting remediation

### DIFF
--- a/org_fedora_oscap/ks/oscap.py
+++ b/org_fedora_oscap/ks/oscap.py
@@ -372,13 +372,14 @@ class OSCAPdata(AddonData):
                                 self.tailoring_path)
 
     def _terminate(self, message):
-        message += "\n" + _("The installation should be aborted.")
-        message += " " + _("Do you wish to continue anyway?")
         if flags.flags.automatedInstall and not flags.flags.ksprompt:
             # cannot have ask in a non-interactive kickstart
             # installation
+            message += "\n" + _("Aborting the installation.")
             raise errors.CmdlineError(message)
 
+        message += "\n" + _("The installation should be aborted.")
+        message += " " + _("Do you wish to continue anyway?")
         answ = errors.errorHandler.ui.showYesNoQuestion(message)
         if answ == errors.ERROR_CONTINUE:
             # prevent any futher actions here by switching to the dry

--- a/org_fedora_oscap/ks/oscap.py
+++ b/org_fedora_oscap/ks/oscap.py
@@ -488,6 +488,17 @@ class OSCAPdata(AddonData):
             # selected
             return
 
+        try:
+            common.assert_scanner_works(
+                chroot=conf.target.system_root, executable="oscap")
+        except Exception as exc:
+            msg_lines = [_(
+                "The 'oscap' scanner doesn't work in the installed system: {error}"
+                .format(error=str(exc)))]
+            msg_lines.append(_("As a result, the installed system can't be hardened."))
+            self._terminate("\n".join(msg_lines))
+            return
+
         target_content_dir = utils.join_paths(conf.target.system_root,
                                               common.TARGET_CONTENT_DIR)
         utils.ensure_dir_exists(target_content_dir)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -77,6 +77,14 @@ def _run_oscap(mock_subprocess, additional_args):
     return expected_args, kwargs
 
 
+def test_oscap_works():
+    assert common.assert_scanner_works(chroot="/")
+    with pytest.raises(common.OSCAPaddonError, match="No such file"):
+        common.assert_scanner_works(chroot="/", executable="i_dont_exist")
+    with pytest.raises(common.OSCAPaddonError, match="non-zero"):
+        common.assert_scanner_works(chroot="/", executable="false")
+
+
 def test_run_oscap_remediate_profile_only(mock_subprocess, monkeypatch):
     return run_oscap_remediate_profile(
         mock_subprocess, monkeypatch,


### PR DESCRIPTION
This PR fixes these related issues:

- Obvious scanner errors are communicated clearly before any serious work involving the scanner is performed.
- Errors result in installer questions rather than in tracebacks.
- The installer feedback has been adjusted to fit the installation mode, so it doesn't ask questions that can't be answered.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2007981