### PR TITLE
Add support for the firstboot remediation

### DIFF
--- a/org_fedora_oscap/common.py
+++ b/org_fedora_oscap/common.py
@@ -29,6 +29,7 @@ import tempfile
 import subprocess
 import zipfile
 import tarfile
+import textwrap
 
 import re
 import logging
@@ -339,6 +340,46 @@ def run_oscap_remediate(profile, fpath, ds_id="", xccdf_id="", tailoring="",
         raise OSCAPaddonError(msg)
 
     return proc.stdout
+
+
+def _schedule_firstboot_remediation(
+        chroot, profile, ds_path, results_path, report_path, ds_id, xccdf_id, tailoring_path):
+    config = textwrap.dedent(f"""\
+    OSCAP_REMEDIATE_DS='{ds_path}'
+    OSCAP_REMEDIATE_PROFILE_ID='{profile}'
+    OSCAP_REMEDIATE_ARF_RESULT='{results_path}'
+    OSCAP_REMEDIATE_HTML_REPORT='{report_path}'
+    """)
+    if ds_id:
+        config += "OSCAP_REMEDIATE_DATASTREAM_ID='{ds_id}'\n"
+    if xccdf_id:
+        config += "OSCAP_REMEDIATE_XCCDF_ID='{xccdf_id}'\n"
+    if tailoring_path:
+        config += "OSCAP_REMEDIATE_TAILORING='{tailoring_path}'\n"
+
+    relative_filename = "var/tmp/oscap-remediate-offline.conf.sh"
+    local_config_filename = f"/{relative_filename}"
+    chroot_config_filename = os.path.join(chroot, relative_filename)
+    with open(chroot_config_filename, "w") as f:
+        f.write(config)
+    os.symlink(local_config_filename,
+               os.path.join(chroot, "system-update"))
+
+
+def schedule_firstboot_remediation(chroot, profile, fpath, ds_id="", xccdf_id="", tailoring=""):
+    if not profile:
+        return ""
+
+    # make sure the directory for the results exists
+    results_dir = os.path.dirname(RESULTS_PATH)
+    results_dir = os.path.normpath(chroot + "/" + results_dir)
+    utils.ensure_dir_exists(results_dir)
+
+    log.info("OSCAP addon: Scheduling firstboot remediation")
+    _schedule_firstboot_remediation(
+        chroot, profile, fpath, RESULTS_PATH, REPORT_PATH, ds_id, xccdf_id, tailoring)
+
+    return ""
 
 
 def extract_data(archive, out_dir, ensure_has_files=None):

--- a/org_fedora_oscap/service/kickstart.py
+++ b/org_fedora_oscap/service/kickstart.py
@@ -76,6 +76,7 @@ class OSCAPKickstartData(AddonData):
             "tailoring-path": self._parse_tailoring_path,
             "fingerprint": self._parse_fingerprint,
             "certificates": self._parse_certificates,
+            "remediate": self._parse_remediate,
         }
 
         line = line.strip()
@@ -144,6 +145,10 @@ class OSCAPKickstartData(AddonData):
 
     def _parse_certificates(self, value):
         self.policy_data.certificates = value
+
+    def _parse_remediate(self, value):
+        assert value in ("none", "post", "firstboot", "both")
+        self.policy_data.remediate = value
 
     def handle_end(self):
         """Handle the end of the section."""
@@ -234,6 +239,9 @@ class OSCAPKickstartData(AddonData):
 
         if self.policy_data.certificates:
             ret += "\n%s" % key_value_pair("certificates", self.policy_data.certificates)
+
+        if self.policy_data.remediate:
+            ret += "\n%s" % key_value_pair("remediate", self.policy_data.remediate)
 
         ret += "\n%end\n\n"
         return ret

--- a/org_fedora_oscap/structures.py
+++ b/org_fedora_oscap/structures.py
@@ -36,6 +36,7 @@ class PolicyData(DBusData):
         self._tailoring_path = ""
         self._fingerprint = ""
         self._certificates = ""
+        self._remediate = ""
 
     def update_from(self, rhs):
         self._content_type = rhs._content_type
@@ -48,6 +49,7 @@ class PolicyData(DBusData):
         self._tailoring_path = rhs._tailoring_path
         self._fingerprint = rhs._fingerprint
         self._certificates = rhs._certificates
+        self._remediate = rhs._remediate
 
     @property
     def content_type(self) -> Str:
@@ -190,3 +192,15 @@ class PolicyData(DBusData):
     @certificates.setter
     def certificates(self, value: Str):
         self._certificates = value
+
+    @property
+    def remediate(self) -> Str:
+        """What remediations to perform
+
+        :return: a remediation mode
+        """
+        return self._remediate
+
+    @remediate.setter
+    def remediate(self, value: Str):
+        self._remediate = value

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -85,7 +85,8 @@ def test_policy_data(interface: OSCAPInterface, callback):
         "cpe-path": get_variant(Str, "/usr/share/oscap/cpe.xml"),
         "tailoring-path": get_variant(Str, "/usr/share/oscap/tailoring.xml"),
         "fingerprint": get_variant(Str, "240f2f18222faa98856c3b4fc50c4195"),
-        "certificates": get_variant(Str, "/usr/share/oscap/cacert.pem")
+        "certificates": get_variant(Str, "/usr/share/oscap/cacert.pem"),
+        "remediate": get_variant(Str, "both"),
     }
     interface.PolicyData = policy_structure
 
@@ -178,11 +179,12 @@ def test_install_with_tasks(service: OSCAPService, interface: OSCAPInterface):
     service.policy_data = data
 
     object_paths = interface.InstallWithTasks()
-    assert len(object_paths) == 2
+    assert len(object_paths) == 3
 
     tasks = TaskContainer.from_object_path_list(object_paths)
     assert isinstance(tasks[0], installation.InstallContentTask)
     assert isinstance(tasks[1], installation.RemediateSystemTask)
+    assert isinstance(tasks[2], installation.ScheduleFirstbootRemediationTask)
 
 
 def test_cancel_tasks(service: OSCAPService):


### PR DESCRIPTION
OpenSCAP supports a new remediation type - a classical scan + remediate that is executed during the first boot.
This PR adds support for this functionality, and allows to control it via a remediate kickstart property.