### PR TITLE
Fix firstboot remediation setup

### DIFF
--- a/org_fedora_oscap/common.py
+++ b/org_fedora_oscap/common.py
@@ -310,8 +310,8 @@ def run_oscap_remediate(profile, fpath, ds_id="", xccdf_id="", tailoring="",
     return proc.stdout
 
 
-def _schedule_firstboot_remediation(
-        chroot, profile, ds_path, results_path, report_path, ds_id, xccdf_id, tailoring_path):
+def _create_firstboot_config_string(
+        profile, ds_path, results_path, report_path, ds_id, xccdf_id, tailoring_path):
     config = textwrap.dedent(f"""\
     OSCAP_REMEDIATE_DS='{ds_path}'
     OSCAP_REMEDIATE_PROFILE_ID='{profile}'
@@ -319,12 +319,18 @@ def _schedule_firstboot_remediation(
     OSCAP_REMEDIATE_HTML_REPORT='{report_path}'
     """)
     if ds_id:
-        config += "OSCAP_REMEDIATE_DATASTREAM_ID='{ds_id}'\n"
+        config += f"OSCAP_REMEDIATE_DATASTREAM_ID='{ds_id}'\n"
     if xccdf_id:
-        config += "OSCAP_REMEDIATE_XCCDF_ID='{xccdf_id}'\n"
+        config += f"OSCAP_REMEDIATE_XCCDF_ID='{xccdf_id}'\n"
     if tailoring_path:
-        config += "OSCAP_REMEDIATE_TAILORING='{tailoring_path}'\n"
+        config += f"OSCAP_REMEDIATE_TAILORING='{tailoring_path}'\n"
+    return config
 
+
+def _schedule_firstboot_remediation(
+        chroot, profile, ds_path, results_path, report_path, ds_id, xccdf_id, tailoring_path):
+    config = _create_firstboot_config_string(
+        profile, ds_path, results_path, report_path, ds_id, xccdf_id, tailoring_path)
     relative_filename = "var/tmp/oscap-remediate-offline.conf.sh"
     local_config_filename = f"/{relative_filename}"
     chroot_config_filename = os.path.join(chroot, relative_filename)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -274,3 +274,18 @@ def test_extract_tailoring_rpm_ensure_filename_there():
            in str(excinfo.value)
 
     shutil.rmtree(temp_path)
+
+
+def test_firstboot_config():
+    config_args = dict(
+        profile="@PROFILE@",
+        ds_path="@DS_PATH@",
+        results_path="@RES_PATH@",
+        report_path="@REP_PATH",
+        ds_id="@DS_ID@",
+        xccdf_id="@XCCDF_ID@",
+        tailoring_path="@TAIL_PATH@",
+    )
+    config_string = common._create_firstboot_config_string(** config_args)
+    for arg in config_args.values():
+        assert arg in config_string


### PR DESCRIPTION
Expand all string substitutions, and add a test that performs a basic sanity check of the generated config.

This is a follow-up for #190 