### PR TITLE
Remove the oscap-utils dependency

### DIFF
--- a/org_fedora_oscap/ks/oscap.py
+++ b/org_fedora_oscap/ks/oscap.py
@@ -54,7 +54,7 @@ SUPPORTED_URL_PREFIXES = ("http://", "https://", "ftp://", "file://"
                           # LABEL:?, hdaX:?,
                           )
 
-REQUIRED_PACKAGES = ("openscap", "openscap-scanner", "openscap-utils",)
+REQUIRED_PACKAGES = ("openscap", "openscap-scanner",)
 
 FINGERPRINT_REGEX = re.compile(r'^[a-z0-9]+$')
 


### PR DESCRIPTION
oscap-utils package is not related to the firstboot remediation,
everything will continue to work even without it being an installation requirement