### PR TITLE
Don't use the execInSysroot function

### DIFF
--- a/org_fedora_oscap/service/installation.py
+++ b/org_fedora_oscap/service/installation.py
@@ -206,8 +206,9 @@ class InstallContentTask(Task):
             package_path = utils.join_paths(self._target_directory, content_name)
 
             # and install it with yum
-            ret = util.execInSysroot(
-                "yum", ["-y", "--nogpg", "install", package_path]
+            ret = util.execWithRedirect(
+                "yum", ["-y", "--nogpg", "install", package_path],
+                root=self._sysroot
             )
 
             if ret != 0:


### PR DESCRIPTION
The `execInSysroot` function is deprecated and will be removed from Anaconda. Call `execWithRedirect` instead.