### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+#### Description:
+
+- _Description here. Replace this text. Don't use the italics format!_
+
+#### Rationale:
+
+- _Rationale here. Replace this text. Don't use the italics format!_
+
+- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._
+
+#### Review Hints:
+
+- _Review hints here. Replace this text. Don't use the italics format!_
+
+- _Use this optional section to give any relevant information which could help the reviewer to more quickly and assertively understand and test the changes._
+
+_Ideas what you can add here:_
+- _virt-install or reanaconda commands_
+- _kickstart you used for setting up the test VM_
+- _description of UI actions that need to be performed to test the PR_
+- _list of steps that you took to test your code_
+- _SCAP content that can be used to test the PR_
+- _log messages that should be observed in Anaconda logs_
+- _bugzillas, mailing list conversations, discussions in other PRs, etc._


### PR DESCRIPTION
The template will help PR authors to make their PRs easily reviewable and will guide them to ensure the greatest transparency during PR contribution. The template is based on the template used in the ComplianceAsCode/content repository.