### PR TITLE
Fix url parsing bug in OAA

### DIFF
--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -67,9 +67,14 @@ class ContentBringer:
 
     @content_uri.setter
     def content_uri(self, uri):
-        scheme, path = uri.split("://", 1)
-        self.content_uri_path = path
-        self.content_uri_scheme = scheme
+        scheme_and_maybe_path = uri.split("://")
+        if len(scheme_and_maybe_path) == 1:
+            msg = (
+                f"Invalid supplied content URL '{uri}', "
+                "use the 'scheme://path' form.")
+            raise KickstartValueError(msg)
+        self.content_uri_path = scheme_and_maybe_path[1]
+        self.content_uri_scheme = scheme_and_maybe_path[0]
 
     def fetch_content(self, what_if_fail, ca_certs_path=""):
         """
@@ -80,7 +85,10 @@ class ContentBringer:
                 should handle them in the calling layer.
             ca_certs_path: Path to the HTTPS certificate file
         """
-        self.content_uri = self._addon_data.content_url
+        try:
+            self.content_uri = self._addon_data.content_url
+        except Exception as exc:
+            what_if_fail(exc)
         shutil.rmtree(self.CONTENT_DOWNLOAD_LOCATION, ignore_errors=True)
         self.CONTENT_DOWNLOAD_LOCATION.mkdir(parents=True, exist_ok=True)
         fetching_thread_name = self._fetch_files(

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -469,6 +469,8 @@ class OSCAPSpoke(NormalSpoke):
         if self._addon_data.profile_id and not selected:
             # profile ID given, but it was impossible to select it -> invalid
             # profile ID given
+            with self._fetch_flag_lock:
+                self._fetching = False
             self._invalid_profile_id()
             return
 


### PR DESCRIPTION
#### Description:

Handle properly the exception that occurs when entering a content URL that doesn't contain `://` as described in https://bugzilla.redhat.com/show_bug.cgi?id=2148509

#### Rationale:

- Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2148509

#### Review Hints:

- Do a GUI install with kickstart that uses scap-security-guide content, but wrong profile. Then, the whole content selection dialog will behave in a weird way. If you don't supply a bad profile, then the dialog will work, and the BZ will be reproducible.
- With this patch, both issues are resolved.

```
%addon org_fedora_oscap
    content-type = scap-security-guide
    profile = anssi_bp28_minimall
%end
```