### PR TITLE
Add libreport-plugin-rhtsupport to essential packages

### DIFF
--- a/org_fedora_oscap/rule_handling.py
+++ b/org_fedora_oscap/rule_handling.py
@@ -42,7 +42,9 @@ __all__ = ["RuleData"]
 
 # Mapping of packages to package environments and/or groups that depends on them
 # See also https://access.redhat.com/solutions/1201413 how to get group IDs.
-# on RHEL8, use e.g. grep -R "<id>" /var/cache/dnf/*
+# on RHEL8, use e.g. grep -R "<id>" /var/cache/dnf/* after running dnf grouplist,
+# and use repoquery --whatrequires to get to a package that is listed in a group -
+# low-level dependencies aren't.
 ESSENTIAL_PACKAGES = {
     "xorg-x11-server-common": {
         "env": ["graphical-server-environment", "workstation-product-environment"],
@@ -51,6 +53,10 @@ ESSENTIAL_PACKAGES = {
     "nfs-utils": {
         "env": ["graphical-server-environment", "workstation-product-environment"],
         "groups": ["workstation-product-environment"],
+    },
+    "libreport-plugin-rhtsupport": {
+        "env": ["graphical-server-environment", "workstation-product-environment"],
+        "groups": ["workstation-product-environment", "core"],
     },
     "tftp": {
         "groups": ["network-server"],


### PR DESCRIPTION
#### Description:

A content profile may require package removal, while the GUI environment requires the package via the `initial-setup` dependency. This PR makes sure that users get a warning at setup-time rather than in the middle of an installation.

#### Rationale:

- The RHEL8 OSPP profile requires the package.
- Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2150355

#### Review hints:

- Run a graphical installation (no special kickstart is required), select the stock RHEL8 8.7 content, and select a "Server with GUI" environment.
- Before this fix, there was no error shown when the package was requested to be removed, after the fix, the situation is the same as with e.g. `nfs-tools`.