### PR TITLE
Refactor content fetching

### DIFF
--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -162,7 +162,7 @@ class ContentBringer:
             self._finish_actual_fetch(fetching_thread_name)
             if fingerprint and dest_filename:
                 self._verify_fingerprint(fingerprint)
-            content = self._analyze_fetched_content(
+            content = ContentBringer.__analyze_fetched_content(
                 fetching_thread_name, fingerprint, dest_filename,
                 expected_path, expected_tailoring, expected_cpe_path)
         except Exception as exc:
@@ -239,13 +239,14 @@ class ContentBringer:
             reduced_files[path] = label
         return reduced_files
 
-    def _analyze_fetched_content(
-                self, wait_for, fingerprint, dest_filename, expected_path,
+    @staticmethod
+    def __analyze_fetched_content(
+                wait_for, fingerprint, dest_filename, expected_path,
                 expected_tailoring, expected_cpe_path):
         actually_fetched_content = wait_for is not None
         fpaths = ContentBringer.__gather_available_files(actually_fetched_content, dest_filename)
 
-        structured_content = ObtainedContent(self.CONTENT_DOWNLOAD_LOCATION)
+        structured_content = ObtainedContent(ContentBringer.CONTENT_DOWNLOAD_LOCATION)
         content_type = ContentBringer.__get_content_type(str(dest_filename))
         log.info(f"OSCAP Addon: started to look at the content")
         if content_type in ("archive", "rpm"):

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -290,7 +290,7 @@ class ContentBringer:
         return fpaths
 
     def use_downloaded_content(self, content):
-        preferred_content = self.get_preferred_content(content)
+        preferred_content = self.get_preferred_content(self._addon_data.content_path, content)
 
         # We know that we have ended up with a datastream-like content,
         # but if we can't convert an archive to a datastream.
@@ -309,9 +309,9 @@ class ContentBringer:
             else:
                 self._addon_data.tailoring_path = str(preferred_tailoring)
 
-    def get_preferred_content(self, content):
-        if self._addon_data.content_path:
-            preferred_content = content.find_expected_usable_content(self._addon_data.content_path)
+    def get_preferred_content(self, content_path, content):
+        if content_path:
+            preferred_content = content.find_expected_usable_content(content_path)
         else:
             preferred_content = content.select_main_usable_content()
         return preferred_content

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -217,10 +217,10 @@ class ContentBringer:
         expected_tailoring = common.get_preinst_tailoring_path(self._addon_data)
         labelled_files = self.allow_one_expected_tailoring_or_no_tailoring(labelled_files, expected_tailoring)
 
-        expected_path = self._addon_data.cpe_path
+        expected_cpe_path = self._addon_data.cpe_path
         categories = (CONTENT_TYPES["CPE_DICT"], )
-        if expected_path:
-            labelled_files = self.reduce_files(labelled_files, expected_path, categories)
+        if expected_cpe_path:
+            labelled_files = self.reduce_files(labelled_files, expected_cpe_path, categories)
 
         return labelled_files
 

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -159,7 +159,7 @@ class ContentBringer:
             )
         return fetching_thread_name
 
-    def finish_content_fetch(self, fetching_thread_name, fingerprint, report_callback, dest_filename,
+    def finish_content_fetch(self, fetching_thread_name, fingerprint, dest_filename,
                              what_if_fail):
         """
         Finish any ongoing fetch and analyze what has been fetched.
@@ -181,7 +181,7 @@ class ContentBringer:
             Instance of ObtainedContent if everything went well, or None.
         """
         try:
-            content = self._finish_actual_fetch(fetching_thread_name, fingerprint, report_callback, dest_filename)
+            content = self._finish_actual_fetch(fetching_thread_name, fingerprint, dest_filename)
         except Exception as exc:
             what_if_fail(exc)
             content = None
@@ -250,7 +250,7 @@ class ContentBringer:
             reduced_files[path] = label
         return reduced_files
 
-    def _finish_actual_fetch(self, wait_for, fingerprint, report_callback, dest_filename):
+    def _finish_actual_fetch(self, wait_for, fingerprint, dest_filename):
         if wait_for:
             log.info(f"OSCAP Addon: Waiting for thread {wait_for}")
             threadMgr.wait(wait_for)

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -289,25 +289,7 @@ class ContentBringer:
                 raise common.OSCAPaddonError("Unsupported content type")
         return fpaths
 
-    def use_downloaded_content(self, content):
-        preferred_content = content.get_preferred_content(self._addon_data.content_path)
 
-        # We know that we have ended up with a datastream-like content,
-        # but if we can't convert an archive to a datastream.
-        # self._addon_data.content_type = "datastream"
-        content_type = self._addon_data.content_type
-        if content_type in ("archive", "rpm"):
-            self._addon_data.content_path = str(preferred_content.relative_to(content.root))
-        else:
-            self._addon_data.content_path = str(preferred_content)
-
-        tailoring_path = self._addon_data.tailoring_path
-        preferred_tailoring = content.get_preferred_tailoring(tailoring_path)
-        if content.tailoring:
-            if content_type in ("archive", "rpm"):
-                self._addon_data.tailoring_path = str(preferred_tailoring.relative_to(content.root))
-            else:
-                self._addon_data.tailoring_path = str(preferred_tailoring)
 
 
 class ObtainedContent:

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -182,6 +182,8 @@ class ContentBringer:
         """
         try:
             self._finish_actual_fetch(fetching_thread_name)
+            if fingerprint and dest_filename:
+                self._verify_fingerprint(dest_filename, fingerprint)
             content = self._analyze_fetched_content(fetching_thread_name, fingerprint, dest_filename)
         except Exception as exc:
             what_if_fail(exc)
@@ -259,10 +261,6 @@ class ContentBringer:
 
     def _analyze_fetched_content(self, wait_for, fingerprint, dest_filename):
         actually_fetched_content = wait_for is not None
-
-        if fingerprint and dest_filename:
-            self._verify_fingerprint(dest_filename, fingerprint)
-
         fpaths = self._gather_available_files(actually_fetched_content, dest_filename)
 
         structured_content = ObtainedContent(self.CONTENT_DOWNLOAD_LOCATION)

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -110,11 +110,10 @@ class ContentBringer:
             what_if_fail(exc)
         shutil.rmtree(self.CONTENT_DOWNLOAD_LOCATION, ignore_errors=True)
         self.CONTENT_DOWNLOAD_LOCATION.mkdir(parents=True, exist_ok=True)
-        fetching_thread_name = self._fetch_files(
-            self.CONTENT_DOWNLOAD_LOCATION, ca_certs_path, what_if_fail)
+        fetching_thread_name = self._fetch_files(ca_certs_path, what_if_fail)
         return fetching_thread_name
 
-    def _fetch_files(self, destdir, ca_certs_path, what_if_fail):
+    def _fetch_files(self, ca_certs_path, what_if_fail):
         with self.activity_lock:
             if self.now_fetching_or_processing:
                 msg = "OSCAP Addon: Strange, it seems that we are already fetching something."
@@ -124,7 +123,7 @@ class ContentBringer:
 
         fetching_thread_name = None
         try:
-            fetching_thread_name = self._start_actual_fetch(destdir, ca_certs_path)
+            fetching_thread_name = self._start_actual_fetch(ca_certs_path)
         except Exception as exc:
             with self.activity_lock:
                 self.now_fetching_or_processing = False
@@ -147,10 +146,10 @@ class ContentBringer:
         dest = destdir / basename
         return dest
 
-    def _start_actual_fetch(self, destdir, ca_certs_path):
+    def _start_actual_fetch(self, ca_certs_path):
         fetching_thread_name = None
 
-        dest = ContentBringer.__get_dest_file_name(self.content_uri, destdir)
+        dest = ContentBringer.__get_dest_file_name(self.content_uri, self.CONTENT_DOWNLOAD_LOCATION)
 
         scheme = self.content_uri.split("://")[0]
         if is_network(scheme):

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -301,7 +301,8 @@ class ContentBringer:
         else:
             self._addon_data.content_path = str(preferred_content)
 
-        preferred_tailoring = self.get_preferred_tailoring(content)
+        tailoring_path = self._addon_data.tailoring_path
+        preferred_tailoring = self.get_preferred_tailoring(tailoring_path, content)
         if content.tailoring:
             if content_type in ("archive", "rpm"):
                 self._addon_data.tailoring_path = str(preferred_tailoring.relative_to(content.root))
@@ -315,8 +316,7 @@ class ContentBringer:
             preferred_content = content.select_main_usable_content()
         return preferred_content
 
-    def get_preferred_tailoring(self, content):
-        tailoring_path = self._addon_data.tailoring_path
+    def get_preferred_tailoring(self, tailoring_path, content):
         if tailoring_path:
             if tailoring_path != str(content.tailoring.relative_to(content.root)):
                 msg = f"Expected a tailoring {tailoring_path}, but it couldn't be found"

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -94,7 +94,8 @@ class ContentBringer:
     def _fetch_files(self, ca_certs_path):
         with self.activity_lock:
             if self.now_fetching_or_processing:
-                msg = "OSCAP Addon: Strange, it seems that we are already fetching something."
+                msg = "OSCAP Addon: Strange, it seems that we are already " \
+                    "fetching something."
                 log.warn(msg)
                 return
             self.now_fetching_or_processing = True
@@ -146,7 +147,9 @@ class ContentBringer:
 
     def _verify_fingerprint(self, fingerprint=""):
         if not fingerprint:
-            log.info("OSCAP Addon: No fingerprint provided, skipping integrity check")
+            log.info(
+                "OSCAP Addon: No fingerprint provided, skipping integrity "
+                "check")
             return
 
         hash_obj = utils.get_hashing_algorithm(fingerprint)
@@ -155,10 +158,12 @@ class ContentBringer:
         if digest != fingerprint:
             log.error(
                 "OSCAP Addon: "
-                f"File {self.dest_file_name} failed integrity check - assumed a "
-                f"{hash_obj.name} hash and '{fingerprint}', got '{digest}'"
+                f"File {self.dest_file_name} failed integrity check - assumed "
+                f"a {hash_obj.name} hash and '{fingerprint}', got '{digest}'"
             )
-            msg = _(f"OSCAP Addon: Integrity check of the content failed - {hash_obj.name} hash didn't match")
+            msg = _(
+                f"OSCAP Addon: Integrity check of the content failed - "
+                f"{hash_obj.name} hash didn't match")
             raise content_handling.ContentCheckError(msg)
         log.info(f"Integrity check passed using {hash_obj.name} hash")
 
@@ -171,16 +176,20 @@ class ContentAnalyzer:
     def __get_content_type(url):
         if url.endswith(".rpm"):
             return "rpm"
-        elif any(url.endswith(arch_type) for arch_type in common.SUPPORTED_ARCHIVES):
+        elif any(
+                url.endswith(arch_type)
+                for arch_type in common.SUPPORTED_ARCHIVES):
             return "archive"
         else:
             return "file"
 
     @staticmethod
-    def __allow_one_expected_tailoring_or_no_tailoring(labelled_files, expected_tailoring):
+    def __allow_one_expected_tailoring_or_no_tailoring(
+            labelled_files, expected_tailoring):
         tailoring_label = CONTENT_TYPES["TAILORING"]
         if expected_tailoring:
-            labelled_files = ContentAnalyzer.reduce_files(labelled_files, expected_tailoring, [tailoring_label])
+            labelled_files = ContentAnalyzer.reduce_files(
+                labelled_files, expected_tailoring, [tailoring_label])
         else:
             labelled_files = {
                 path: label for path, label in labelled_files.items()
@@ -189,30 +198,41 @@ class ContentAnalyzer:
         return labelled_files
 
     @staticmethod
-    def __filter_discovered_content(labelled_files, expected_path, expected_tailoring, expected_cpe_path):
-        categories = (CONTENT_TYPES["DATASTREAM"], CONTENT_TYPES["XCCDF_CHECKLIST"])
+    def __filter_discovered_content(
+            labelled_files, expected_path, expected_tailoring,
+            expected_cpe_path):
+        categories = (
+            CONTENT_TYPES["DATASTREAM"],
+            CONTENT_TYPES["XCCDF_CHECKLIST"])
         if expected_path:
-            labelled_files = ContentAnalyzer.reduce_files(labelled_files, expected_path, categories)
+            labelled_files = ContentAnalyzer.reduce_files(
+                labelled_files, expected_path, categories)
 
-        labelled_files = ContentAnalyzer.__allow_one_expected_tailoring_or_no_tailoring(labelled_files, expected_tailoring)
+        labelled_files = \
+            ContentAnalyzer.__allow_one_expected_tailoring_or_no_tailoring(
+                labelled_files, expected_tailoring)
 
         categories = (CONTENT_TYPES["CPE_DICT"], )
         if expected_cpe_path:
-            labelled_files = ContentAnalyzer.reduce_files(labelled_files, expected_cpe_path, categories)
+            labelled_files = ContentAnalyzer.reduce_files(
+                labelled_files, expected_cpe_path, categories)
 
         return labelled_files
 
     @staticmethod
     def reduce_files(labelled_files, expected_path, categories):
         reduced_files = dict()
-        if not path_is_present_among_paths(expected_path, labelled_files.keys()):
+        if not path_is_present_among_paths(
+                expected_path, labelled_files.keys()):
             msg = (
-                f"Expected a file {expected_path} to be part of the supplied content, "
-                f"but it was not the case, got only {list(labelled_files.keys())}"
+                f"Expected a file {expected_path} to be part of the supplied "
+                f"content, but it was not the case, got only "
+                f"{list(labelled_files.keys())}"
             )
             raise content_handling.ContentHandlingError(msg)
         for path, label in labelled_files.items():
-            if label in categories and not paths_are_equivalent(path, expected_path):
+            if label in categories and not paths_are_equivalent(
+                    path, expected_path):
                 continue
             reduced_files[path] = label
         return reduced_files
@@ -235,9 +255,11 @@ class ContentAnalyzer:
                 wait_for, fingerprint, dest_filename, expected_path,
                 expected_tailoring, expected_cpe_path):
         actually_fetched_content = wait_for is not None
-        fpaths = ContentAnalyzer.__gather_available_files(actually_fetched_content, dest_filename)
+        fpaths = ContentAnalyzer.__gather_available_files(
+            actually_fetched_content, dest_filename)
 
-        structured_content = ObtainedContent(ContentAnalyzer.CONTENT_DOWNLOAD_LOCATION)
+        structured_content = ObtainedContent(
+            ContentAnalyzer.CONTENT_DOWNLOAD_LOCATION)
         content_type = ContentAnalyzer.__get_content_type(str(dest_filename))
         log.info(f"OSCAP Addon: started to look at the content")
         if content_type in ("archive", "rpm"):
@@ -264,12 +286,14 @@ class ContentAnalyzer:
             if not dest_filename:  # using scap-security-guide
                 fpaths = [ContentAnalyzer.DEFAULT_SSG_DATA_STREAM_PATH]
             else:  # Using downloaded XCCDF/OVAL/DS/tailoring
-                fpaths = pathlib.Path(ContentAnalyzer.CONTENT_DOWNLOAD_LOCATION).rglob("*")
+                fpaths = pathlib.Path(
+                    ContentAnalyzer.CONTENT_DOWNLOAD_LOCATION).rglob("*")
                 fpaths = [str(p) for p in fpaths if p.is_file()]
         else:
             dest_filename = pathlib.Path(dest_filename)
             # RPM is an archive at this phase
-            content_type = ContentAnalyzer.__get_content_type(str(dest_filename))
+            content_type = ContentAnalyzer.__get_content_type(
+                str(dest_filename))
             if content_type in ("archive", "rpm"):
                 try:
                     fpaths = common.extract_data(
@@ -277,7 +301,9 @@ class ContentAnalyzer:
                         str(dest_filename.parent)
                     )
                 except common.ExtractionError as err:
-                    msg = f"Failed to extract the '{dest_filename}' archive: {str(err)}"
+                    msg = (
+                        f"Failed to extract the '{dest_filename}' "
+                        f"archive: {str(err)}")
                     log.error("OSCAP Addon: " + msg)
                     raise err
 
@@ -286,8 +312,6 @@ class ContentAnalyzer:
             else:
                 raise common.OSCAPaddonError("Unsupported content type")
         return fpaths
-
-
 
 
 class ObtainedContent:

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -136,10 +136,9 @@ class ContentBringer:
         # We are not finished yet with the fetch
         return fetching_thread_name
 
-    def _start_actual_fetch(self, scheme, path, destdir, ca_certs_path):
-        fetching_thread_name = None
-        url = scheme + "://" + path
-
+    @staticmethod
+    def __get_dest_file_name(url, destdir):
+        path = url.split("://")[1]
         if "/" not in path:
             msg = f"Missing the path component of the '{url}' URL"
             raise KickstartValueError(msg)
@@ -149,6 +148,13 @@ class ContentBringer:
             raise KickstartValueError(msg)
 
         dest = destdir / basename
+        return dest
+
+    def _start_actual_fetch(self, scheme, path, destdir, ca_certs_path):
+        fetching_thread_name = None
+        url = scheme + "://" + path
+
+        dest = ContentBringer.__get_dest_file_name(url, destdir)
 
         if is_network(scheme):
             fetching_thread_name = data_fetch.wait_and_fetch_net_data(

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -42,7 +42,7 @@ class ContentBringer:
     CONTENT_DOWNLOAD_LOCATION = pathlib.Path(common.INSTALLATION_CONTENT_DIR)
 
     def __init__(self, what_if_fail):
-        self._content_uri = ""
+        self._valid_content_uri = ""
         self.dest_file_name = ""
 
         self.activity_lock = threading.Lock()
@@ -53,7 +53,7 @@ class ContentBringer:
 
     @property
     def content_uri(self):
-        return self._content_uri
+        return self._valid_content_uri
 
     @content_uri.setter
     def content_uri(self, uri):
@@ -71,7 +71,7 @@ class ContentBringer:
         if not basename:
             msg = f"Unable to deduce basename from the '{uri}' URL"
             raise KickstartValueError(msg)
-        self._content_uri = uri
+        self._valid_content_uri = uri
         self.dest_file_name = self.CONTENT_DOWNLOAD_LOCATION / basename
 
     def fetch_content(self, content_uri, ca_certs_path=""):

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -41,12 +41,13 @@ def path_is_present_among_paths(path, paths):
 class ContentBringer:
     CONTENT_DOWNLOAD_LOCATION = pathlib.Path(common.INSTALLATION_CONTENT_DIR)
 
-    def __init__(self):
+    def __init__(self, what_if_fail):
         self._content_uri = ""
         self.dest_file_name = ""
 
         self.activity_lock = threading.Lock()
         self.now_fetching_or_processing = False
+        self.what_if_fail = what_if_fail
 
         self.CONTENT_DOWNLOAD_LOCATION.mkdir(parents=True, exist_ok=True)
 
@@ -73,25 +74,23 @@ class ContentBringer:
         self._content_uri = uri
         self.dest_file_name = self.CONTENT_DOWNLOAD_LOCATION / basename
 
-    def fetch_content(self, content_uri, what_if_fail, ca_certs_path=""):
+    def fetch_content(self, content_uri, ca_certs_path=""):
         """
         Initiate fetch of the content into an appropriate directory
 
         Args:
-            what_if_fail: Callback accepting exception as an argument that
-                should handle them in the calling layer.
             ca_certs_path: Path to the HTTPS certificate file
         """
         try:
             self.content_uri = content_uri
         except Exception as exc:
-            what_if_fail(exc)
+            self.what_if_fail(exc)
         shutil.rmtree(self.CONTENT_DOWNLOAD_LOCATION, ignore_errors=True)
         self.CONTENT_DOWNLOAD_LOCATION.mkdir(parents=True, exist_ok=True)
-        fetching_thread_name = self._fetch_files(ca_certs_path, what_if_fail)
+        fetching_thread_name = self._fetch_files(ca_certs_path)
         return fetching_thread_name
 
-    def _fetch_files(self, ca_certs_path, what_if_fail):
+    def _fetch_files(self, ca_certs_path):
         with self.activity_lock:
             if self.now_fetching_or_processing:
                 msg = "OSCAP Addon: Strange, it seems that we are already fetching something."
@@ -105,7 +104,7 @@ class ContentBringer:
         except Exception as exc:
             with self.activity_lock:
                 self.now_fetching_or_processing = False
-            what_if_fail(exc)
+            self.what_if_fail(exc)
 
         # We are not finished yet with the fetch
         return fetching_thread_name
@@ -127,14 +126,13 @@ class ContentBringer:
             )
         return fetching_thread_name
 
-    def finish_content_fetch(
-            self, fetching_thread_name, fingerprint, what_if_fail):
+    def finish_content_fetch(self, fetching_thread_name, fingerprint):
         try:
             self._finish_actual_fetch(fetching_thread_name)
             if fingerprint:
                 self._verify_fingerprint(fingerprint)
         except Exception as exc:
-            what_if_fail(exc)
+            self.what_if_fail(exc)
         finally:
             with self.activity_lock:
                 self.now_fetching_or_processing = False

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -308,11 +308,6 @@ class ContentBringer:
             else:
                 self._addon_data.tailoring_path = str(preferred_tailoring)
 
-    def use_system_content(self, content=None):
-        self._addon_data.clear_all()
-        self._addon_data.content_type = "scap-security-guide"
-        self._addon_data.content_path = common.get_ssg_path()
-
     def get_preferred_content(self, content):
         if self._addon_data.content_path:
             preferred_content = content.find_expected_usable_content(self._addon_data.content_path)

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -210,7 +210,8 @@ class ContentBringer:
             }
         return labelled_files
 
-    def filter_discovered_content(self, labelled_files, expected_path, expected_tailoring, expected_cpe_path):
+    @staticmethod
+    def __filter_discovered_content(labelled_files, expected_path, expected_tailoring, expected_cpe_path):
         categories = (CONTENT_TYPES["DATASTREAM"], CONTENT_TYPES["XCCDF_CHECKLIST"])
         if expected_path:
             labelled_files = ContentBringer.reduce_files(labelled_files, expected_path, categories)
@@ -251,7 +252,7 @@ class ContentBringer:
             structured_content.add_content_archive(dest_filename)
 
         labelled_filenames = content_handling.identify_files(fpaths)
-        labelled_filenames = self.filter_discovered_content(
+        labelled_filenames = ContentBringer.__filter_discovered_content(
             labelled_filenames, expected_path, expected_tailoring,
             expected_cpe_path)
 

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -79,6 +79,7 @@ class ContentBringer:
         Initiate fetch of the content into an appropriate directory
 
         Args:
+            content_uri: URI location of the content to be fetched
             ca_certs_path: Path to the HTTPS certificate file
         """
         try:

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -183,7 +183,7 @@ class ContentBringer:
         try:
             self._finish_actual_fetch(fetching_thread_name)
             if fingerprint and dest_filename:
-                self._verify_fingerprint(dest_filename, fingerprint)
+                self._verify_fingerprint(fingerprint)
             content = self._analyze_fetched_content(fetching_thread_name, fingerprint, dest_filename)
         except Exception as exc:
             what_if_fail(exc)
@@ -194,18 +194,18 @@ class ContentBringer:
 
         return content
 
-    def _verify_fingerprint(self, dest_filename, fingerprint=""):
+    def _verify_fingerprint(self, fingerprint=""):
         if not fingerprint:
             log.info("OSCAP Addon: No fingerprint provided, skipping integrity check")
             return
 
         hash_obj = utils.get_hashing_algorithm(fingerprint)
-        digest = utils.get_file_fingerprint(dest_filename,
+        digest = utils.get_file_fingerprint(self.dest_file_name,
                                             hash_obj)
         if digest != fingerprint:
             log.error(
                 "OSCAP Addon: "
-                f"File {dest_filename} failed integrity check - assumed a "
+                f"File {self.dest_file_name} failed integrity check - assumed a "
                 f"{hash_obj.name} hash and '{fingerprint}', got '{digest}'"
             )
             msg = _(f"OSCAP Addon: Integrity check of the content failed - {hash_obj.name} hash didn't match")

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -128,11 +128,10 @@ class ContentBringer:
         return fetching_thread_name
 
     def finish_content_fetch(
-            self, fetching_thread_name, fingerprint, dest_filename,
-            what_if_fail):
+            self, fetching_thread_name, fingerprint, what_if_fail):
         try:
             self._finish_actual_fetch(fetching_thread_name)
-            if fingerprint and dest_filename:
+            if fingerprint:
                 self._verify_fingerprint(fingerprint)
         except Exception as exc:
             what_if_fail(exc)

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -197,8 +197,7 @@ class ContentBringer:
             raise content_handling.ContentCheckError(msg)
         log.info(f"Integrity check passed using {hash_obj.name} hash")
 
-    def allow_one_expected_tailoring_or_no_tailoring(self, labelled_files):
-        expected_tailoring = common.get_preinst_tailoring_path(self._addon_data)
+    def allow_one_expected_tailoring_or_no_tailoring(self, labelled_files, expected_tailoring):
         tailoring_label = CONTENT_TYPES["TAILORING"]
         if expected_tailoring:
             labelled_files = self.reduce_files(labelled_files, expected_tailoring, [tailoring_label])
@@ -215,7 +214,8 @@ class ContentBringer:
         if expected_path:
             labelled_files = self.reduce_files(labelled_files, expected_path, categories)
 
-        labelled_files = self.allow_one_expected_tailoring_or_no_tailoring(labelled_files)
+        expected_tailoring = common.get_preinst_tailoring_path(self._addon_data)
+        labelled_files = self.allow_one_expected_tailoring_or_no_tailoring(labelled_files, expected_tailoring)
 
         expected_path = self._addon_data.cpe_path
         categories = (CONTENT_TYPES["CPE_DICT"], )

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -181,7 +181,8 @@ class ContentBringer:
             Instance of ObtainedContent if everything went well, or None.
         """
         try:
-            content = self._finish_actual_fetch(fetching_thread_name, fingerprint, dest_filename)
+            self._finish_actual_fetch(fetching_thread_name)
+            content = self._analyze_fetched_content(fetching_thread_name, fingerprint, dest_filename)
         except Exception as exc:
             what_if_fail(exc)
             content = None
@@ -250,11 +251,13 @@ class ContentBringer:
             reduced_files[path] = label
         return reduced_files
 
-    def _finish_actual_fetch(self, wait_for, fingerprint, dest_filename):
+    def _finish_actual_fetch(self, wait_for):
         if wait_for:
             log.info(f"OSCAP Addon: Waiting for thread {wait_for}")
             threadMgr.wait(wait_for)
             log.info(f"OSCAP Addon: Finished waiting for thread {wait_for}")
+
+    def _analyze_fetched_content(self, wait_for, fingerprint, dest_filename):
         actually_fetched_content = wait_for is not None
 
         if fingerprint and dest_filename:

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -290,7 +290,7 @@ class ContentBringer:
         return fpaths
 
     def use_downloaded_content(self, content):
-        preferred_content = self.get_preferred_content(self._addon_data.content_path, content)
+        preferred_content = content.get_preferred_content(self._addon_data.content_path)
 
         # We know that we have ended up with a datastream-like content,
         # but if we can't convert an archive to a datastream.
@@ -308,13 +308,6 @@ class ContentBringer:
                 self._addon_data.tailoring_path = str(preferred_tailoring.relative_to(content.root))
             else:
                 self._addon_data.tailoring_path = str(preferred_tailoring)
-
-    def get_preferred_content(self, content_path, content):
-        if content_path:
-            preferred_content = content.find_expected_usable_content(content_path)
-        else:
-            preferred_content = content.select_main_usable_content()
-        return preferred_content
 
 
 class ObtainedContent:
@@ -421,3 +414,10 @@ class ObtainedContent:
                 msg = f"Expected a tailoring {tailoring_path}, but it couldn't be found"
                 raise content_handling.ContentHandlingError(msg)
         return self.tailoring
+
+    def get_preferred_content(self, content_path):
+        if content_path:
+            preferred_content = self.find_expected_usable_content(content_path)
+        else:
+            preferred_content = self.select_main_usable_content()
+        return preferred_content

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -243,7 +243,7 @@ class ContentBringer:
                 self, wait_for, fingerprint, dest_filename, expected_path,
                 expected_tailoring, expected_cpe_path):
         actually_fetched_content = wait_for is not None
-        fpaths = self._gather_available_files(actually_fetched_content, dest_filename)
+        fpaths = ContentBringer.__gather_available_files(actually_fetched_content, dest_filename)
 
         structured_content = ObtainedContent(self.CONTENT_DOWNLOAD_LOCATION)
         content_type = ContentBringer.__get_content_type(str(dest_filename))
@@ -265,13 +265,14 @@ class ContentBringer:
         log.info(f"OSCAP Addon: finished looking at the content")
         return structured_content
 
-    def _gather_available_files(self, actually_fetched_content, dest_filename):
+    @staticmethod
+    def __gather_available_files(actually_fetched_content, dest_filename):
         fpaths = []
         if not actually_fetched_content:
             if not dest_filename:  # using scap-security-guide
-                fpaths = [self.DEFAULT_SSG_DATA_STREAM_PATH]
+                fpaths = [ContentBringer.DEFAULT_SSG_DATA_STREAM_PATH]
             else:  # Using downloaded XCCDF/OVAL/DS/tailoring
-                fpaths = pathlib.Path(self.CONTENT_DOWNLOAD_LOCATION).rglob("*")
+                fpaths = pathlib.Path(ContentBringer.CONTENT_DOWNLOAD_LOCATION).rglob("*")
                 fpaths = [str(p) for p in fpaths if p.is_file()]
         else:
             dest_filename = pathlib.Path(dest_filename)

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -40,7 +40,6 @@ def path_is_present_among_paths(path, paths):
 
 class ContentBringer:
     CONTENT_DOWNLOAD_LOCATION = pathlib.Path(common.INSTALLATION_CONTENT_DIR)
-    DEFAULT_SSG_DATA_STREAM_PATH = f"{common.SSG_DIR}/{common.SSG_CONTENT}"
 
     def __init__(self):
         self._content_uri = ""
@@ -50,15 +49,6 @@ class ContentBringer:
         self.now_fetching_or_processing = False
 
         self.CONTENT_DOWNLOAD_LOCATION.mkdir(parents=True, exist_ok=True)
-
-    @staticmethod
-    def __get_content_type(url):
-        if url.endswith(".rpm"):
-            return "rpm"
-        elif any(url.endswith(arch_type) for arch_type in common.SUPPORTED_ARCHIVES):
-            return "archive"
-        else:
-            return "file"
 
     @property
     def content_uri(self):
@@ -162,7 +152,7 @@ class ContentBringer:
             self._finish_actual_fetch(fetching_thread_name)
             if fingerprint and dest_filename:
                 self._verify_fingerprint(fingerprint)
-            content = ContentBringer.__analyze_fetched_content(
+            content = ContentAnalyzer.analyze_fetched_content(
                 fetching_thread_name, fingerprint, dest_filename,
                 expected_path, expected_tailoring, expected_cpe_path)
         except Exception as exc:
@@ -198,11 +188,25 @@ class ContentBringer:
             raise content_handling.ContentCheckError(msg)
         log.info(f"Integrity check passed using {hash_obj.name} hash")
 
+
+class ContentAnalyzer:
+    CONTENT_DOWNLOAD_LOCATION = pathlib.Path(common.INSTALLATION_CONTENT_DIR)
+    DEFAULT_SSG_DATA_STREAM_PATH = f"{common.SSG_DIR}/{common.SSG_CONTENT}"
+
+    @staticmethod
+    def __get_content_type(url):
+        if url.endswith(".rpm"):
+            return "rpm"
+        elif any(url.endswith(arch_type) for arch_type in common.SUPPORTED_ARCHIVES):
+            return "archive"
+        else:
+            return "file"
+
     @staticmethod
     def __allow_one_expected_tailoring_or_no_tailoring(labelled_files, expected_tailoring):
         tailoring_label = CONTENT_TYPES["TAILORING"]
         if expected_tailoring:
-            labelled_files = ContentBringer.reduce_files(labelled_files, expected_tailoring, [tailoring_label])
+            labelled_files = ContentAnalyzer.reduce_files(labelled_files, expected_tailoring, [tailoring_label])
         else:
             labelled_files = {
                 path: label for path, label in labelled_files.items()
@@ -214,13 +218,13 @@ class ContentBringer:
     def __filter_discovered_content(labelled_files, expected_path, expected_tailoring, expected_cpe_path):
         categories = (CONTENT_TYPES["DATASTREAM"], CONTENT_TYPES["XCCDF_CHECKLIST"])
         if expected_path:
-            labelled_files = ContentBringer.reduce_files(labelled_files, expected_path, categories)
+            labelled_files = ContentAnalyzer.reduce_files(labelled_files, expected_path, categories)
 
-        labelled_files = ContentBringer.__allow_one_expected_tailoring_or_no_tailoring(labelled_files, expected_tailoring)
+        labelled_files = ContentAnalyzer.__allow_one_expected_tailoring_or_no_tailoring(labelled_files, expected_tailoring)
 
         categories = (CONTENT_TYPES["CPE_DICT"], )
         if expected_cpe_path:
-            labelled_files = ContentBringer.reduce_files(labelled_files, expected_cpe_path, categories)
+            labelled_files = ContentAnalyzer.reduce_files(labelled_files, expected_cpe_path, categories)
 
         return labelled_files
 
@@ -240,20 +244,20 @@ class ContentBringer:
         return reduced_files
 
     @staticmethod
-    def __analyze_fetched_content(
+    def analyze_fetched_content(
                 wait_for, fingerprint, dest_filename, expected_path,
                 expected_tailoring, expected_cpe_path):
         actually_fetched_content = wait_for is not None
-        fpaths = ContentBringer.__gather_available_files(actually_fetched_content, dest_filename)
+        fpaths = ContentAnalyzer.__gather_available_files(actually_fetched_content, dest_filename)
 
-        structured_content = ObtainedContent(ContentBringer.CONTENT_DOWNLOAD_LOCATION)
-        content_type = ContentBringer.__get_content_type(str(dest_filename))
+        structured_content = ObtainedContent(ContentAnalyzer.CONTENT_DOWNLOAD_LOCATION)
+        content_type = ContentAnalyzer.__get_content_type(str(dest_filename))
         log.info(f"OSCAP Addon: started to look at the content")
         if content_type in ("archive", "rpm"):
             structured_content.add_content_archive(dest_filename)
 
         labelled_filenames = content_handling.identify_files(fpaths)
-        labelled_filenames = ContentBringer.__filter_discovered_content(
+        labelled_filenames = ContentAnalyzer.__filter_discovered_content(
             labelled_filenames, expected_path, expected_tailoring,
             expected_cpe_path)
 
@@ -271,14 +275,14 @@ class ContentBringer:
         fpaths = []
         if not actually_fetched_content:
             if not dest_filename:  # using scap-security-guide
-                fpaths = [ContentBringer.DEFAULT_SSG_DATA_STREAM_PATH]
+                fpaths = [ContentAnalyzer.DEFAULT_SSG_DATA_STREAM_PATH]
             else:  # Using downloaded XCCDF/OVAL/DS/tailoring
-                fpaths = pathlib.Path(ContentBringer.CONTENT_DOWNLOAD_LOCATION).rglob("*")
+                fpaths = pathlib.Path(ContentAnalyzer.CONTENT_DOWNLOAD_LOCATION).rglob("*")
                 fpaths = [str(p) for p in fpaths if p.is_file()]
         else:
             dest_filename = pathlib.Path(dest_filename)
             # RPM is an archive at this phase
-            content_type = ContentBringer.__get_content_type(str(dest_filename))
+            content_type = ContentAnalyzer.__get_content_type(str(dest_filename))
             if content_type in ("archive", "rpm"):
                 try:
                     fpaths = common.extract_data(

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -104,7 +104,7 @@ class ContentBringer:
         self._content_uri = uri
         self.dest_file_name = self.CONTENT_DOWNLOAD_LOCATION / basename
 
-    def fetch_content(self, what_if_fail, ca_certs_path=""):
+    def fetch_content(self, content_uri, what_if_fail, ca_certs_path=""):
         """
         Initiate fetch of the content into an appropriate directory
 
@@ -114,7 +114,7 @@ class ContentBringer:
             ca_certs_path: Path to the HTTPS certificate file
         """
         try:
-            self.content_uri = self._addon_data.content_url
+            self.content_uri = content_uri
         except Exception as exc:
             what_if_fail(exc)
         shutil.rmtree(self.CONTENT_DOWNLOAD_LOCATION, ignore_errors=True)

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -132,36 +132,34 @@ class ContentBringer:
         # We are not finished yet with the fetch
         return fetching_thread_name
 
-    @staticmethod
-    def __get_dest_file_name(url, destdir):
-        path = url.split("://")[1]
+    @property
+    def dest_file_name(self):
+        path = self.content_uri.split("://")[1]
         if "/" not in path:
-            msg = f"Missing the path component of the '{url}' URL"
+            msg = f"Missing the path component of the '{self.content_uri}' URL"
             raise KickstartValueError(msg)
         basename = path.rsplit("/", 1)[1]
         if not basename:
-            msg = f"Unable to deduce basename from the '{url}' URL"
+            msg = f"Unable to deduce basename from the '{self.content_uri}' URL"
             raise KickstartValueError(msg)
 
-        dest = destdir / basename
+        dest = self.CONTENT_DOWNLOAD_LOCATION / basename
         return dest
 
     def _start_actual_fetch(self, ca_certs_path):
         fetching_thread_name = None
 
-        dest = ContentBringer.__get_dest_file_name(self.content_uri, self.CONTENT_DOWNLOAD_LOCATION)
-
         scheme = self.content_uri.split("://")[0]
         if is_network(scheme):
             fetching_thread_name = data_fetch.wait_and_fetch_net_data(
                 self.content_uri,
-                dest,
+                self.dest_file_name,
                 ca_certs_path
             )
         else:  # invalid schemes are handled down the road
             fetching_thread_name = data_fetch.fetch_local_data(
                 self.content_uri,
-                dest,
+                self.dest_file_name,
             )
         return fetching_thread_name
 

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -208,16 +208,13 @@ class ContentBringer:
             }
         return labelled_files
 
-    def filter_discovered_content(self, labelled_files):
-        expected_path = common.get_preinst_content_path(self._addon_data)
+    def filter_discovered_content(self, labelled_files, expected_path, expected_tailoring, expected_cpe_path):
         categories = (CONTENT_TYPES["DATASTREAM"], CONTENT_TYPES["XCCDF_CHECKLIST"])
         if expected_path:
             labelled_files = self.reduce_files(labelled_files, expected_path, categories)
 
-        expected_tailoring = common.get_preinst_tailoring_path(self._addon_data)
         labelled_files = self.allow_one_expected_tailoring_or_no_tailoring(labelled_files, expected_tailoring)
 
-        expected_cpe_path = self._addon_data.cpe_path
         categories = (CONTENT_TYPES["CPE_DICT"], )
         if expected_cpe_path:
             labelled_files = self.reduce_files(labelled_files, expected_cpe_path, categories)
@@ -249,7 +246,12 @@ class ContentBringer:
             structured_content.add_content_archive(dest_filename)
 
         labelled_filenames = content_handling.identify_files(fpaths)
-        labelled_filenames = self.filter_discovered_content(labelled_filenames)
+        expected_path = common.get_preinst_content_path(self._addon_data)
+        expected_tailoring = common.get_preinst_tailoring_path(self._addon_data)
+        expected_cpe_path = self._addon_data.cpe_path
+        labelled_filenames = self.filter_discovered_content(
+            labelled_filenames, expected_path, expected_tailoring,
+            expected_cpe_path)
 
         for fname, label in labelled_filenames.items():
             structured_content.add_file(str(fname), label)

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -63,8 +63,7 @@ class ContentBringer:
     DEFAULT_SSG_DATA_STREAM_PATH = f"{common.SSG_DIR}/{common.SSG_CONTENT}"
 
     def __init__(self, addon_data):
-        self.content_uri_scheme = ""
-        self.content_uri_path = ""
+        self._content_uri = ""
         self.fetched_content = ""
 
         self.activity_lock = threading.Lock()
@@ -84,7 +83,7 @@ class ContentBringer:
 
     @property
     def content_uri(self):
-        return self.content_uri_scheme + "://" + self.content_uri_path
+        return self._content_uri
 
     @content_uri.setter
     def content_uri(self, uri):
@@ -94,8 +93,7 @@ class ContentBringer:
                 f"Invalid supplied content URL '{uri}', "
                 "use the 'scheme://path' form.")
             raise KickstartValueError(msg)
-        self.content_uri_path = scheme_and_maybe_path[1]
-        self.content_uri_scheme = scheme_and_maybe_path[0]
+        self._content_uri = uri
 
     def fetch_content(self, what_if_fail, ca_certs_path=""):
         """
@@ -113,11 +111,10 @@ class ContentBringer:
         shutil.rmtree(self.CONTENT_DOWNLOAD_LOCATION, ignore_errors=True)
         self.CONTENT_DOWNLOAD_LOCATION.mkdir(parents=True, exist_ok=True)
         fetching_thread_name = self._fetch_files(
-            self.content_uri_scheme, self.content_uri_path,
             self.CONTENT_DOWNLOAD_LOCATION, ca_certs_path, what_if_fail)
         return fetching_thread_name
 
-    def _fetch_files(self, scheme, path, destdir, ca_certs_path, what_if_fail):
+    def _fetch_files(self, destdir, ca_certs_path, what_if_fail):
         with self.activity_lock:
             if self.now_fetching_or_processing:
                 msg = "OSCAP Addon: Strange, it seems that we are already fetching something."
@@ -127,7 +124,7 @@ class ContentBringer:
 
         fetching_thread_name = None
         try:
-            fetching_thread_name = self._start_actual_fetch(scheme, path, destdir, ca_certs_path)
+            fetching_thread_name = self._start_actual_fetch(destdir, ca_certs_path)
         except Exception as exc:
             with self.activity_lock:
                 self.now_fetching_or_processing = False
@@ -150,21 +147,21 @@ class ContentBringer:
         dest = destdir / basename
         return dest
 
-    def _start_actual_fetch(self, scheme, path, destdir, ca_certs_path):
+    def _start_actual_fetch(self, destdir, ca_certs_path):
         fetching_thread_name = None
-        url = scheme + "://" + path
 
-        dest = ContentBringer.__get_dest_file_name(url, destdir)
+        dest = ContentBringer.__get_dest_file_name(self.content_uri, destdir)
 
+        scheme = self.content_uri.split("://")[0]
         if is_network(scheme):
             fetching_thread_name = data_fetch.wait_and_fetch_net_data(
-                url,
+                self.content_uri,
                 dest,
                 ca_certs_path
             )
         else:  # invalid schemes are handled down the road
             fetching_thread_name = data_fetch.fetch_local_data(
-                url,
+                self.content_uri,
                 dest,
             )
         return fetching_thread_name

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -42,7 +42,7 @@ class ContentBringer:
     CONTENT_DOWNLOAD_LOCATION = pathlib.Path(common.INSTALLATION_CONTENT_DIR)
     DEFAULT_SSG_DATA_STREAM_PATH = f"{common.SSG_DIR}/{common.SSG_CONTENT}"
 
-    def __init__(self, addon_data):
+    def __init__(self):
         self._content_uri = ""
         self.dest_file_name = ""
 
@@ -50,8 +50,6 @@ class ContentBringer:
         self.now_fetching_or_processing = False
 
         self.CONTENT_DOWNLOAD_LOCATION.mkdir(parents=True, exist_ok=True)
-
-        self._addon_data = addon_data
 
     def get_content_type(self, url):
         if url.endswith(".rpm"):

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -201,7 +201,7 @@ class ContentBringer:
     def allow_one_expected_tailoring_or_no_tailoring(self, labelled_files, expected_tailoring):
         tailoring_label = CONTENT_TYPES["TAILORING"]
         if expected_tailoring:
-            labelled_files = self.reduce_files(labelled_files, expected_tailoring, [tailoring_label])
+            labelled_files = ContentBringer.reduce_files(labelled_files, expected_tailoring, [tailoring_label])
         else:
             labelled_files = {
                 path: label for path, label in labelled_files.items()
@@ -212,17 +212,18 @@ class ContentBringer:
     def filter_discovered_content(self, labelled_files, expected_path, expected_tailoring, expected_cpe_path):
         categories = (CONTENT_TYPES["DATASTREAM"], CONTENT_TYPES["XCCDF_CHECKLIST"])
         if expected_path:
-            labelled_files = self.reduce_files(labelled_files, expected_path, categories)
+            labelled_files = ContentBringer.reduce_files(labelled_files, expected_path, categories)
 
         labelled_files = self.allow_one_expected_tailoring_or_no_tailoring(labelled_files, expected_tailoring)
 
         categories = (CONTENT_TYPES["CPE_DICT"], )
         if expected_cpe_path:
-            labelled_files = self.reduce_files(labelled_files, expected_cpe_path, categories)
+            labelled_files = ContentBringer.reduce_files(labelled_files, expected_cpe_path, categories)
 
         return labelled_files
 
-    def reduce_files(self, labelled_files, expected_path, categories):
+    @staticmethod
+    def reduce_files(labelled_files, expected_path, categories):
         reduced_files = dict()
         if not path_is_present_among_paths(expected_path, labelled_files.keys()):
             msg = (

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -139,7 +139,7 @@ class ContentBringer:
         return fetching_thread_name
 
     def finish_content_fetch(self, fetching_thread_name, fingerprint, dest_filename,
-                             what_if_fail):
+                             what_if_fail, expected_path, expected_tailoring, expected_cpe_path):
         """
         Finish any ongoing fetch and analyze what has been fetched.
 
@@ -163,9 +163,6 @@ class ContentBringer:
             self._finish_actual_fetch(fetching_thread_name)
             if fingerprint and dest_filename:
                 self._verify_fingerprint(fingerprint)
-            expected_path = common.get_preinst_content_path(self._addon_data)
-            expected_tailoring = common.get_preinst_tailoring_path(self._addon_data)
-            expected_cpe_path = self._addon_data.cpe_path
             content = self._analyze_fetched_content(
                 fetching_thread_name, fingerprint, dest_filename,
                 expected_path, expected_tailoring, expected_cpe_path)

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -64,7 +64,6 @@ class ContentBringer:
 
     def __init__(self, addon_data):
         self._content_uri = ""
-        self.fetched_content = ""
         self.dest_file_name = ""
 
         self.activity_lock = threading.Lock()

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -14,7 +14,6 @@ from org_fedora_oscap import data_fetch, utils
 from org_fedora_oscap import common
 from org_fedora_oscap import content_handling
 from org_fedora_oscap.content_handling import CONTENT_TYPES
-from org_fedora_oscap import rule_handling
 
 from org_fedora_oscap.common import _
 
@@ -25,25 +24,6 @@ def is_network(scheme):
     return any(
         scheme.startswith(net_prefix)
         for net_prefix in data_fetch.NET_URL_PREFIXES)
-
-
-def clear_all(data):
-    data.content_type = ""
-    data.content_url = ""
-    data.datastream_id = ""
-    data.xccdf_id = ""
-    data.profile_id = ""
-    data.content_path = ""
-    data.cpe_path = ""
-    data.tailoring_path = ""
-
-    data.fingerprint = ""
-
-    data.certificates = ""
-
-    # internal values
-    data.rule_data = rule_handling.RuleData()
-    data.dry_run = False
 
 
 def paths_are_equivalent(p1, p2):
@@ -329,7 +309,7 @@ class ContentBringer:
                 self._addon_data.tailoring_path = str(preferred_tailoring)
 
     def use_system_content(self, content=None):
-        clear_all(self._addon_data)
+        self._addon_data.clear_all()
         self._addon_data.content_type = "scap-security-guide"
         self._addon_data.content_path = common.get_ssg_path()
 

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -198,7 +198,8 @@ class ContentBringer:
             raise content_handling.ContentCheckError(msg)
         log.info(f"Integrity check passed using {hash_obj.name} hash")
 
-    def allow_one_expected_tailoring_or_no_tailoring(self, labelled_files, expected_tailoring):
+    @staticmethod
+    def __allow_one_expected_tailoring_or_no_tailoring(labelled_files, expected_tailoring):
         tailoring_label = CONTENT_TYPES["TAILORING"]
         if expected_tailoring:
             labelled_files = ContentBringer.reduce_files(labelled_files, expected_tailoring, [tailoring_label])
@@ -214,7 +215,7 @@ class ContentBringer:
         if expected_path:
             labelled_files = ContentBringer.reduce_files(labelled_files, expected_path, categories)
 
-        labelled_files = self.allow_one_expected_tailoring_or_no_tailoring(labelled_files, expected_tailoring)
+        labelled_files = ContentBringer.__allow_one_expected_tailoring_or_no_tailoring(labelled_files, expected_tailoring)
 
         categories = (CONTENT_TYPES["CPE_DICT"], )
         if expected_cpe_path:

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -127,8 +127,9 @@ class ContentBringer:
             )
         return fetching_thread_name
 
-    def finish_content_fetch(self, fetching_thread_name, fingerprint, dest_filename,
-                             what_if_fail, expected_path, expected_tailoring, expected_cpe_path):
+    def finish_content_fetch(
+            self, fetching_thread_name, fingerprint, dest_filename,
+            what_if_fail):
         try:
             self._finish_actual_fetch(fetching_thread_name)
             if fingerprint and dest_filename:

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -51,7 +51,8 @@ class ContentBringer:
 
         self.CONTENT_DOWNLOAD_LOCATION.mkdir(parents=True, exist_ok=True)
 
-    def get_content_type(self, url):
+    @staticmethod
+    def __get_content_type(url):
         if url.endswith(".rpm"):
             return "rpm"
         elif any(url.endswith(arch_type) for arch_type in common.SUPPORTED_ARCHIVES):
@@ -242,7 +243,7 @@ class ContentBringer:
         fpaths = self._gather_available_files(actually_fetched_content, dest_filename)
 
         structured_content = ObtainedContent(self.CONTENT_DOWNLOAD_LOCATION)
-        content_type = self.get_content_type(str(dest_filename))
+        content_type = ContentBringer.__get_content_type(str(dest_filename))
         log.info(f"OSCAP Addon: started to look at the content")
         if content_type in ("archive", "rpm"):
             structured_content.add_content_archive(dest_filename)
@@ -272,7 +273,7 @@ class ContentBringer:
         else:
             dest_filename = pathlib.Path(dest_filename)
             # RPM is an archive at this phase
-            content_type = self.get_content_type(str(dest_filename))
+            content_type = ContentBringer.__get_content_type(str(dest_filename))
             if content_type in ("archive", "rpm"):
                 try:
                     fpaths = common.extract_data(

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -129,40 +129,15 @@ class ContentBringer:
 
     def finish_content_fetch(self, fetching_thread_name, fingerprint, dest_filename,
                              what_if_fail, expected_path, expected_tailoring, expected_cpe_path):
-        """
-        Finish any ongoing fetch and analyze what has been fetched.
-
-        After the fetch is completed, it analyzes verifies fetched content if applicable,
-        analyzes it and compiles into an instance of ObtainedContent.
-
-        Args:
-            fetching_thread_name: Name of the fetching thread
-                or None if we are only after the analysis
-            fingerprint: A checksum for downloaded file verification
-            report_callback: Means for the method to send user-relevant messages outside
-            dest_filename: The target of the fetch operation. Can be falsy -
-                in this case there is no content filename defined
-            what_if_fail: Callback accepting exception as an argument
-                that should handle them in the calling layer.
-
-        Returns:
-            Instance of ObtainedContent if everything went well, or None.
-        """
         try:
             self._finish_actual_fetch(fetching_thread_name)
             if fingerprint and dest_filename:
                 self._verify_fingerprint(fingerprint)
-            content = ContentAnalyzer.analyze_fetched_content(
-                fetching_thread_name, fingerprint, dest_filename,
-                expected_path, expected_tailoring, expected_cpe_path)
         except Exception as exc:
             what_if_fail(exc)
-            content = None
         finally:
             with self.activity_lock:
                 self.now_fetching_or_processing = False
-
-        return content
 
     def _finish_actual_fetch(self, wait_for):
         if wait_for:
@@ -244,7 +219,20 @@ class ContentAnalyzer:
         return reduced_files
 
     @staticmethod
-    def analyze_fetched_content(
+    def analyze(
+            fetching_thread_name, fingerprint, dest_filename, what_if_fail,
+            expected_path, expected_tailoring, expected_cpe_path):
+        try:
+            content = ContentAnalyzer.__analyze_fetched_content(
+                fetching_thread_name, fingerprint, dest_filename,
+                expected_path, expected_tailoring, expected_cpe_path)
+        except Exception as exc:
+            what_if_fail(exc)
+            content = None
+        return content
+
+    @staticmethod
+    def __analyze_fetched_content(
                 wait_for, fingerprint, dest_filename, expected_path,
                 expected_tailoring, expected_cpe_path):
         actually_fetched_content = wait_for is not None

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -193,6 +193,12 @@ class ContentBringer:
 
         return content
 
+    def _finish_actual_fetch(self, wait_for):
+        if wait_for:
+            log.info(f"OSCAP Addon: Waiting for thread {wait_for}")
+            threadMgr.wait(wait_for)
+            log.info(f"OSCAP Addon: Finished waiting for thread {wait_for}")
+
     def _verify_fingerprint(self, fingerprint=""):
         if not fingerprint:
             log.info("OSCAP Addon: No fingerprint provided, skipping integrity check")
@@ -251,12 +257,6 @@ class ContentBringer:
                 continue
             reduced_files[path] = label
         return reduced_files
-
-    def _finish_actual_fetch(self, wait_for):
-        if wait_for:
-            log.info(f"OSCAP Addon: Waiting for thread {wait_for}")
-            threadMgr.wait(wait_for)
-            log.info(f"OSCAP Addon: Finished waiting for thread {wait_for}")
 
     def _analyze_fetched_content(self, wait_for, fingerprint, dest_filename):
         actually_fetched_content = wait_for is not None

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -302,7 +302,7 @@ class ContentBringer:
             self._addon_data.content_path = str(preferred_content)
 
         tailoring_path = self._addon_data.tailoring_path
-        preferred_tailoring = self.get_preferred_tailoring(tailoring_path, content)
+        preferred_tailoring = content.get_preferred_tailoring(tailoring_path)
         if content.tailoring:
             if content_type in ("archive", "rpm"):
                 self._addon_data.tailoring_path = str(preferred_tailoring.relative_to(content.root))
@@ -315,13 +315,6 @@ class ContentBringer:
         else:
             preferred_content = content.select_main_usable_content()
         return preferred_content
-
-    def get_preferred_tailoring(self, tailoring_path, content):
-        if tailoring_path:
-            if tailoring_path != str(content.tailoring.relative_to(content.root)):
-                msg = f"Expected a tailoring {tailoring_path}, but it couldn't be found"
-                raise content_handling.ContentHandlingError(msg)
-        return content.tailoring
 
 
 class ObtainedContent:
@@ -421,3 +414,10 @@ class ObtainedContent:
                 "Couldn't find a valid datastream or a valid XCCDF-OVAL file tuple "
                 "among the available content")
             raise content_handling.ContentHandlingError(msg)
+
+    def get_preferred_tailoring(self, tailoring_path):
+        if tailoring_path:
+            if tailoring_path != str(self.tailoring.relative_to(self.root)):
+                msg = f"Expected a tailoring {tailoring_path}, but it couldn't be found"
+                raise content_handling.ContentHandlingError(msg)
+        return self.tailoring

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -163,7 +163,12 @@ class ContentBringer:
             self._finish_actual_fetch(fetching_thread_name)
             if fingerprint and dest_filename:
                 self._verify_fingerprint(fingerprint)
-            content = self._analyze_fetched_content(fetching_thread_name, fingerprint, dest_filename)
+            expected_path = common.get_preinst_content_path(self._addon_data)
+            expected_tailoring = common.get_preinst_tailoring_path(self._addon_data)
+            expected_cpe_path = self._addon_data.cpe_path
+            content = self._analyze_fetched_content(
+                fetching_thread_name, fingerprint, dest_filename,
+                expected_path, expected_tailoring, expected_cpe_path)
         except Exception as exc:
             what_if_fail(exc)
             content = None
@@ -235,7 +240,9 @@ class ContentBringer:
             reduced_files[path] = label
         return reduced_files
 
-    def _analyze_fetched_content(self, wait_for, fingerprint, dest_filename):
+    def _analyze_fetched_content(
+                self, wait_for, fingerprint, dest_filename, expected_path,
+                expected_tailoring, expected_cpe_path):
         actually_fetched_content = wait_for is not None
         fpaths = self._gather_available_files(actually_fetched_content, dest_filename)
 
@@ -246,9 +253,6 @@ class ContentBringer:
             structured_content.add_content_archive(dest_filename)
 
         labelled_filenames = content_handling.identify_files(fpaths)
-        expected_path = common.get_preinst_content_path(self._addon_data)
-        expected_tailoring = common.get_preinst_tailoring_path(self._addon_data)
-        expected_cpe_path = self._addon_data.cpe_path
         labelled_filenames = self.filter_discovered_content(
             labelled_filenames, expected_path, expected_tailoring,
             expected_cpe_path)

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -65,6 +65,7 @@ class ContentBringer:
     def __init__(self, addon_data):
         self._content_uri = ""
         self.fetched_content = ""
+        self.dest_file_name = ""
 
         self.activity_lock = threading.Lock()
         self.now_fetching_or_processing = False
@@ -93,7 +94,16 @@ class ContentBringer:
                 f"Invalid supplied content URL '{uri}', "
                 "use the 'scheme://path' form.")
             raise KickstartValueError(msg)
+        path = scheme_and_maybe_path[1]
+        if "/" not in path:
+            msg = f"Missing the path component of the '{uri}' URL"
+            raise KickstartValueError(msg)
+        basename = path.rsplit("/", 1)[1]
+        if not basename:
+            msg = f"Unable to deduce basename from the '{uri}' URL"
+            raise KickstartValueError(msg)
         self._content_uri = uri
+        self.dest_file_name = self.CONTENT_DOWNLOAD_LOCATION / basename
 
     def fetch_content(self, what_if_fail, ca_certs_path=""):
         """
@@ -131,20 +141,6 @@ class ContentBringer:
 
         # We are not finished yet with the fetch
         return fetching_thread_name
-
-    @property
-    def dest_file_name(self):
-        path = self.content_uri.split("://")[1]
-        if "/" not in path:
-            msg = f"Missing the path component of the '{self.content_uri}' URL"
-            raise KickstartValueError(msg)
-        basename = path.rsplit("/", 1)[1]
-        if not basename:
-            msg = f"Unable to deduce basename from the '{self.content_uri}' URL"
-            raise KickstartValueError(msg)
-
-        dest = self.CONTENT_DOWNLOAD_LOCATION / basename
-        return dest
 
     def _start_actual_fetch(self, ca_certs_path):
         fetching_thread_name = None

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -434,7 +434,7 @@ class OSCAPSpoke(NormalSpoke):
         if actually_fetched_content:
             content_path = common.get_raw_preinst_content_path(self._policy_data)
             self.content_bringer.finish_content_fetch(
-                wait_for, self._policy_data.fingerprint, content_path,
+                wait_for, self._policy_data.fingerprint,
                 self._handle_error)
 
         expected_path = common.get_preinst_content_path(self._policy_data)

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -436,14 +436,14 @@ class OSCAPSpoke(NormalSpoke):
 
         if actually_fetched_content:
             content_path = common.get_raw_preinst_content_path(self._policy_data)
+            self.content_bringer.finish_content_fetch(
+                wait_for, self._policy_data.fingerprint, content_path,
+                self._handle_error)
 
         expected_path = common.get_preinst_content_path(self._policy_data)
         expected_tailoring = common.get_preinst_tailoring_path(self._policy_data)
         expected_cpe_path = self._policy_data.cpe_path
 
-        self.content_bringer.finish_content_fetch(
-            wait_for, self._policy_data.fingerprint, content_path,
-            self._handle_error)
         content = content_discovery.ContentAnalyzer.analyze(
             wait_for, self._policy_data.fingerprint, content_path,
             self._handle_error, expected_path, expected_tailoring,

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -262,7 +262,7 @@ class OSCAPSpoke(NormalSpoke):
         self._anaconda_spokes_initialized = threading.Event()
         self.initialization_controller.init_done.connect(self._all_anaconda_spokes_initialized)
 
-        self.content_bringer = content_discovery.ContentBringer(self._policy_data)
+        self.content_bringer = content_discovery.ContentBringer()
         self._content_handler = None
 
     def _all_anaconda_spokes_initialized(self):

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -262,7 +262,7 @@ class OSCAPSpoke(NormalSpoke):
         self._anaconda_spokes_initialized = threading.Event()
         self.initialization_controller.init_done.connect(self._all_anaconda_spokes_initialized)
 
-        self.content_bringer = content_discovery.ContentBringer()
+        self.content_bringer = content_discovery.ContentBringer(self._handle_error)
         self._content_handler = None
 
     def _all_anaconda_spokes_initialized(self):
@@ -406,7 +406,7 @@ class OSCAPSpoke(NormalSpoke):
             log.info(f"OSCAP Addon: Actually fetching content from somewhere")
             thread_name = self.content_bringer.fetch_content(
                 self._policy_data.content_url,
-                self._handle_error, self._policy_data.certificates)
+                self._policy_data.certificates)
 
         # pylint: disable-msg=E1101
         hubQ.send_message(self.__class__.__name__,
@@ -434,8 +434,7 @@ class OSCAPSpoke(NormalSpoke):
         if actually_fetched_content:
             content_path = common.get_raw_preinst_content_path(self._policy_data)
             self.content_bringer.finish_content_fetch(
-                wait_for, self._policy_data.fingerprint,
-                self._handle_error)
+                wait_for, self._policy_data.fingerprint)
 
         expected_path = common.get_preinst_content_path(self._policy_data)
         expected_tailoring = common.get_preinst_tailoring_path(self._policy_data)

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -456,7 +456,7 @@ class OSCAPSpoke(NormalSpoke):
 
         try:
             if actually_fetched_content:
-                self._policy_data.use_downloaded_content(content)
+                self._use_downloaded_content(content)
 
             preinst_content_path = common.get_preinst_content_path(self._policy_data)
             preinst_tailoring_path = common.get_preinst_tailoring_path(self._policy_data)
@@ -1219,6 +1219,34 @@ class OSCAPSpoke(NormalSpoke):
         self._refresh_ui()
 
     def on_use_ssg_clicked(self, *args):
-        self._policy_data.use_system_content()
+        self._use_system_content()
         self._save_policy_data()
         self._fetch_data_and_initialize()
+
+    def _use_system_content(self):
+        self._policy_data.clear_all()
+        self._policy_data.content_type = "scap-security-guide"
+        self._policy_data.content_path = common.get_ssg_path()
+
+    def _use_downloaded_content(self, content):
+        preferred_content = content.get_preferred_content(
+            self._policy_data.content_path)
+
+        # We know that we have ended up with a datastream-like content,
+        # but if we can't convert an archive to a datastream.
+        # self._policy_data.content_type = "datastream"
+        content_type = self._policy_data.content_type
+        if content_type in ("archive", "rpm"):
+            self._policy_data.content_path = str(
+                preferred_content.relative_to(content.root))
+        else:
+            self._policy_data.content_path = str(preferred_content)
+
+        preferred_tailoring = content.get_preferred_tailoring(
+            self._policy_data.tailoring_path)
+        if content.tailoring:
+            if content_type in ("archive", "rpm"):
+                self._policy_data.tailoring_path = str(
+                    preferred_tailoring.relative_to(content.root))
+            else:
+                self._policy_data.tailoring_path = str(preferred_tailoring)

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -437,7 +437,7 @@ class OSCAPSpoke(NormalSpoke):
             content_path = common.get_raw_preinst_content_path(self._policy_data)
 
         content = self.content_bringer.finish_content_fetch(
-            wait_for, self._policy_data.fingerprint, update_progress_label,
+            wait_for, self._policy_data.fingerprint,
             content_path, self._handle_error)
         if not content:
             with self._fetch_flag_lock:

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -437,9 +437,14 @@ class OSCAPSpoke(NormalSpoke):
         if actually_fetched_content:
             content_path = common.get_raw_preinst_content_path(self._policy_data)
 
+        expected_path = common.get_preinst_content_path(self._policy_data)
+        expected_tailoring = common.get_preinst_tailoring_path(self._policy_data)
+        expected_cpe_path = self._policy_data.cpe_path
+
         content = self.content_bringer.finish_content_fetch(
-            wait_for, self._policy_data.fingerprint,
-            content_path, self._handle_error)
+            wait_for, self._policy_data.fingerprint, content_path,
+            self._handle_error, expected_path, expected_tailoring,
+            expected_cpe_path)
         if not content:
             with self._fetch_flag_lock:
                 self._fetching = False

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -441,7 +441,11 @@ class OSCAPSpoke(NormalSpoke):
         expected_tailoring = common.get_preinst_tailoring_path(self._policy_data)
         expected_cpe_path = self._policy_data.cpe_path
 
-        content = self.content_bringer.finish_content_fetch(
+        self.content_bringer.finish_content_fetch(
+            wait_for, self._policy_data.fingerprint, content_path,
+            self._handle_error, expected_path, expected_tailoring,
+            expected_cpe_path)
+        content = content_discovery.ContentAnalyzer.analyze(
             wait_for, self._policy_data.fingerprint, content_path,
             self._handle_error, expected_path, expected_tailoring,
             expected_cpe_path)

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -443,8 +443,7 @@ class OSCAPSpoke(NormalSpoke):
 
         self.content_bringer.finish_content_fetch(
             wait_for, self._policy_data.fingerprint, content_path,
-            self._handle_error, expected_path, expected_tailoring,
-            expected_cpe_path)
+            self._handle_error)
         content = content_discovery.ContentAnalyzer.analyze(
             wait_for, self._policy_data.fingerprint, content_path,
             self._handle_error, expected_path, expected_tailoring,

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -428,9 +428,6 @@ class OSCAPSpoke(NormalSpoke):
         :type wait_for: str or None
 
         """
-        def update_progress_label(msg):
-            fire_gtk_action(self._progress_label.set_text(msg))
-
         content_path = None
         actually_fetched_content = wait_for is not None
 

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -1215,6 +1215,6 @@ class OSCAPSpoke(NormalSpoke):
         self._refresh_ui()
 
     def on_use_ssg_clicked(self, *args):
-        self.content_bringer.use_system_content()
+        self._policy_data.use_system_content()
         self._save_policy_data()
         self._fetch_data_and_initialize()

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -452,7 +452,7 @@ class OSCAPSpoke(NormalSpoke):
 
         try:
             if actually_fetched_content:
-                self.content_bringer.use_downloaded_content(content)
+                self._policy_data.use_downloaded_content(content)
 
             preinst_content_path = common.get_preinst_content_path(self._policy_data)
             preinst_tailoring_path = common.get_preinst_tailoring_path(self._policy_data)

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -405,6 +405,7 @@ class OSCAPSpoke(NormalSpoke):
         if self._policy_data.content_url and self._policy_data.content_type != "scap-security-guide":
             log.info(f"OSCAP Addon: Actually fetching content from somewhere")
             thread_name = self.content_bringer.fetch_content(
+                self._policy_data.content_url,
                 self._handle_error, self._policy_data.certificates)
 
         # pylint: disable-msg=E1101

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -868,7 +868,7 @@ class OSCAPSpoke(NormalSpoke):
 
     @async_action_wait
     def _wrong_content(self, msg):
-        content_discovery.clear_all(self._policy_data)
+        self._policy_data.clear_all()
         really_hide(self._progress_spinner)
         self._fetch_button.set_sensitive(True)
         self._content_url_entry.set_sensitive(True)
@@ -1211,7 +1211,7 @@ class OSCAPSpoke(NormalSpoke):
 
     def on_change_content_clicked(self, *args):
         self._unselect_profile(self._active_profile)
-        content_discovery.clear_all(self._policy_data)
+        self._policy_data.clear_all()
         self._refresh_ui()
 
     def on_use_ssg_clicked(self, *args):

--- a/org_fedora_oscap/service/installation.py
+++ b/org_fedora_oscap/service/installation.py
@@ -93,9 +93,13 @@ class PrepareValidContent(Task):
         if self._policy_data.content_type != "scap-security-guide":
             content_dest = self._file_path
 
+        expected_path = common.get_preinst_content_path(self._policy_data)
+        expected_tailoring = common.get_preinst_tailoring_path(self._policy_data)
+        expected_cpe_path = self._policy_data.cpe_path
         content = self.content_bringer.finish_content_fetch(
             fetching_thread_name, self._policy_data.fingerprint,
-            content_dest, _handle_error)
+            content_dest, _handle_error, expected_path, expected_tailoring,
+            expected_cpe_path)
 
         if not content:
             # this shouldn't happen because error handling is supposed to

--- a/org_fedora_oscap/service/installation.py
+++ b/org_fedora_oscap/service/installation.py
@@ -94,7 +94,7 @@ class PrepareValidContent(Task):
 
         content = self.content_bringer.finish_content_fetch(
             fetching_thread_name, self._policy_data.fingerprint,
-            lambda msg: log.info("OSCAP Addon: " + msg), content_dest, _handle_error)
+            content_dest, _handle_error)
 
         if not content:
             # this shouldn't happen because error handling is supposed to

--- a/org_fedora_oscap/service/installation.py
+++ b/org_fedora_oscap/service/installation.py
@@ -73,7 +73,7 @@ class PrepareValidContent(Task):
         self._policy_data = policy_data
         self._file_path = file_path
         self._content_path = content_path
-        self.content_bringer = content_discovery.ContentBringer(policy_data)
+        self.content_bringer = content_discovery.ContentBringer()
 
     @property
     def name(self):

--- a/org_fedora_oscap/service/installation.py
+++ b/org_fedora_oscap/service/installation.py
@@ -96,9 +96,10 @@ class PrepareValidContent(Task):
         expected_path = common.get_preinst_content_path(self._policy_data)
         expected_tailoring = common.get_preinst_tailoring_path(self._policy_data)
         expected_cpe_path = self._policy_data.cpe_path
-        self.content_bringer.finish_content_fetch(
-            fetching_thread_name, self._policy_data.fingerprint,
-            content_dest, _handle_error)
+        if fetching_thread_name is not None:
+            self.content_bringer.finish_content_fetch(
+                fetching_thread_name, self._policy_data.fingerprint,
+                content_dest, _handle_error)
         content = content_discovery.ContentAnalyzer.analyze(
             fetching_thread_name, self._policy_data.fingerprint,
             content_dest, _handle_error, expected_path, expected_tailoring,

--- a/org_fedora_oscap/service/installation.py
+++ b/org_fedora_oscap/service/installation.py
@@ -73,7 +73,7 @@ class PrepareValidContent(Task):
         self._policy_data = policy_data
         self._file_path = file_path
         self._content_path = content_path
-        self.content_bringer = content_discovery.ContentBringer()
+        self.content_bringer = content_discovery.ContentBringer(_handle_error)
 
     @property
     def name(self):
@@ -87,7 +87,7 @@ class PrepareValidContent(Task):
             # content not available/fetched yet
             fetching_thread_name = self.content_bringer.fetch_content(
                 self._policy_data.content_url,
-                _handle_error, self._policy_data.certificates)
+                self._policy_data.certificates)
 
         content_dest = None
         fingerprint = None
@@ -100,7 +100,7 @@ class PrepareValidContent(Task):
         expected_cpe_path = self._policy_data.cpe_path
         if fetching_thread_name is not None:
             self.content_bringer.finish_content_fetch(
-                fetching_thread_name, fingerprint, _handle_error)
+                fetching_thread_name, fingerprint)
         content = content_discovery.ContentAnalyzer.analyze(
             fetching_thread_name, self._policy_data.fingerprint,
             content_dest, _handle_error, expected_path, expected_tailoring,

--- a/org_fedora_oscap/service/installation.py
+++ b/org_fedora_oscap/service/installation.py
@@ -90,16 +90,17 @@ class PrepareValidContent(Task):
                 _handle_error, self._policy_data.certificates)
 
         content_dest = None
+        fingerprint = None
         if self._policy_data.content_type != "scap-security-guide":
             content_dest = self._file_path
+            fingerprint = self._policy_data.fingerprint
 
         expected_path = common.get_preinst_content_path(self._policy_data)
         expected_tailoring = common.get_preinst_tailoring_path(self._policy_data)
         expected_cpe_path = self._policy_data.cpe_path
         if fetching_thread_name is not None:
             self.content_bringer.finish_content_fetch(
-                fetching_thread_name, self._policy_data.fingerprint,
-                content_dest, _handle_error)
+                fetching_thread_name, fingerprint, _handle_error)
         content = content_discovery.ContentAnalyzer.analyze(
             fetching_thread_name, self._policy_data.fingerprint,
             content_dest, _handle_error, expected_path, expected_tailoring,

--- a/org_fedora_oscap/service/installation.py
+++ b/org_fedora_oscap/service/installation.py
@@ -110,7 +110,7 @@ class PrepareValidContent(Task):
 
         try:
             # just check that preferred content exists
-            _ = self.content_bringer.get_preferred_content(content)
+            _ = self.content_bringer.get_preferred_content(self._policy_data.content_path, content)
         except Exception as exc:
             terminate(str(exc))
 

--- a/org_fedora_oscap/service/installation.py
+++ b/org_fedora_oscap/service/installation.py
@@ -110,7 +110,7 @@ class PrepareValidContent(Task):
 
         try:
             # just check that preferred content exists
-            _ = self.content_bringer.get_preferred_content(self._policy_data.content_path, content)
+            _ = content.get_preferred_content(self._policy_data.content_path)
         except Exception as exc:
             terminate(str(exc))
 

--- a/org_fedora_oscap/service/installation.py
+++ b/org_fedora_oscap/service/installation.py
@@ -98,8 +98,7 @@ class PrepareValidContent(Task):
         expected_cpe_path = self._policy_data.cpe_path
         self.content_bringer.finish_content_fetch(
             fetching_thread_name, self._policy_data.fingerprint,
-            content_dest, _handle_error, expected_path, expected_tailoring,
-            expected_cpe_path)
+            content_dest, _handle_error)
         content = content_discovery.ContentAnalyzer.analyze(
             fetching_thread_name, self._policy_data.fingerprint,
             content_dest, _handle_error, expected_path, expected_tailoring,

--- a/org_fedora_oscap/service/installation.py
+++ b/org_fedora_oscap/service/installation.py
@@ -96,7 +96,11 @@ class PrepareValidContent(Task):
         expected_path = common.get_preinst_content_path(self._policy_data)
         expected_tailoring = common.get_preinst_tailoring_path(self._policy_data)
         expected_cpe_path = self._policy_data.cpe_path
-        content = self.content_bringer.finish_content_fetch(
+        self.content_bringer.finish_content_fetch(
+            fetching_thread_name, self._policy_data.fingerprint,
+            content_dest, _handle_error, expected_path, expected_tailoring,
+            expected_cpe_path)
+        content = content_discovery.ContentAnalyzer.analyze(
             fetching_thread_name, self._policy_data.fingerprint,
             content_dest, _handle_error, expected_path, expected_tailoring,
             expected_cpe_path)

--- a/org_fedora_oscap/service/installation.py
+++ b/org_fedora_oscap/service/installation.py
@@ -86,6 +86,7 @@ class PrepareValidContent(Task):
         if not os.path.exists(self._content_path):
             # content not available/fetched yet
             fetching_thread_name = self.content_bringer.fetch_content(
+                self._policy_data.content_url,
                 _handle_error, self._policy_data.certificates)
 
         content_dest = None

--- a/org_fedora_oscap/structures.py
+++ b/org_fedora_oscap/structures.py
@@ -18,6 +18,8 @@
 from dasbus.structure import DBusData
 from dasbus.typing import *  # pylint: disable=wildcard-import
 
+from org_fedora_oscap import common
+
 __all__ = ["PolicyData"]
 
 
@@ -202,3 +204,8 @@ class PolicyData(DBusData):
         self.tailoring_path = ""
         self.fingerprint = ""
         self.certificates = ""
+
+    def use_system_content(self):
+        self.clear_all()
+        self.content_type = "scap-security-guide"
+        self.content_path = common.get_ssg_path()

--- a/org_fedora_oscap/structures.py
+++ b/org_fedora_oscap/structures.py
@@ -204,27 +204,3 @@ class PolicyData(DBusData):
         self.tailoring_path = ""
         self.fingerprint = ""
         self.certificates = ""
-
-    def use_system_content(self):
-        self.clear_all()
-        self.content_type = "scap-security-guide"
-        self.content_path = common.get_ssg_path()
-
-    def use_downloaded_content(self, content):
-        preferred_content = content.get_preferred_content(self.content_path)
-
-        # We know that we have ended up with a datastream-like content,
-        # but if we can't convert an archive to a datastream.
-        # self.content_type = "datastream"
-        content_type = self.content_type
-        if content_type in ("archive", "rpm"):
-            self.content_path = str(preferred_content.relative_to(content.root))
-        else:
-            self.content_path = str(preferred_content)
-
-        preferred_tailoring = content.get_preferred_tailoring(self.tailoring_path)
-        if content.tailoring:
-            if content_type in ("archive", "rpm"):
-                self.tailoring_path = str(preferred_tailoring.relative_to(content.root))
-            else:
-                self.tailoring_path = str(preferred_tailoring)

--- a/org_fedora_oscap/structures.py
+++ b/org_fedora_oscap/structures.py
@@ -18,8 +18,6 @@
 from dasbus.structure import DBusData
 from dasbus.typing import *  # pylint: disable=wildcard-import
 
-from org_fedora_oscap import rule_handling
-
 __all__ = ["PolicyData"]
 
 
@@ -202,11 +200,5 @@ class PolicyData(DBusData):
         self.content_path = ""
         self.cpe_path = ""
         self.tailoring_path = ""
-
         self.fingerprint = ""
-
         self.certificates = ""
-
-        # internal values
-        self.rule_data = rule_handling.RuleData()
-        self.dry_run = False

--- a/org_fedora_oscap/structures.py
+++ b/org_fedora_oscap/structures.py
@@ -18,6 +18,8 @@
 from dasbus.structure import DBusData
 from dasbus.typing import *  # pylint: disable=wildcard-import
 
+from org_fedora_oscap import rule_handling
+
 __all__ = ["PolicyData"]
 
 
@@ -190,3 +192,21 @@ class PolicyData(DBusData):
     @certificates.setter
     def certificates(self, value: Str):
         self._certificates = value
+
+    def clear_all(self):
+        self.content_type = ""
+        self.content_url = ""
+        self.datastream_id = ""
+        self.xccdf_id = ""
+        self.profile_id = ""
+        self.content_path = ""
+        self.cpe_path = ""
+        self.tailoring_path = ""
+
+        self.fingerprint = ""
+
+        self.certificates = ""
+
+        # internal values
+        self.rule_data = rule_handling.RuleData()
+        self.dry_run = False

--- a/org_fedora_oscap/structures.py
+++ b/org_fedora_oscap/structures.py
@@ -209,3 +209,22 @@ class PolicyData(DBusData):
         self.clear_all()
         self.content_type = "scap-security-guide"
         self.content_path = common.get_ssg_path()
+
+    def use_downloaded_content(self, content):
+        preferred_content = content.get_preferred_content(self.content_path)
+
+        # We know that we have ended up with a datastream-like content,
+        # but if we can't convert an archive to a datastream.
+        # self.content_type = "datastream"
+        content_type = self.content_type
+        if content_type in ("archive", "rpm"):
+            self.content_path = str(preferred_content.relative_to(content.root))
+        else:
+            self.content_path = str(preferred_content)
+
+        preferred_tailoring = content.get_preferred_tailoring(self.tailoring_path)
+        if content.tailoring:
+            if content_type in ("archive", "rpm"):
+                self.tailoring_path = str(preferred_tailoring.relative_to(content.root))
+            else:
+                self.tailoring_path = str(preferred_tailoring)

--- a/tests/test_content_discovery.py
+++ b/tests/test_content_discovery.py
@@ -22,7 +22,7 @@ def labelled_files():
 
 
 def test_reduce(labelled_files):
-    bringer = tested_module.ContentBringer()
+    analyzer = tested_module.ContentAnalyzer()
 
     d_count = 0
     x_count = 0
@@ -32,22 +32,22 @@ def test_reduce(labelled_files):
         elif l == "X":
             x_count += 1
 
-    reduced = bringer.reduce_files(labelled_files, "dir/datastream", ["D"])
+    reduced = analyzer.reduce_files(labelled_files, "dir/datastream", ["D"])
     assert len(reduced) == len(labelled_files) - d_count + 1
     assert "dir/datastream" in reduced
 
-    reduced = bringer.reduce_files(labelled_files, "dir/datastream", ["D", "X"])
+    reduced = analyzer.reduce_files(labelled_files, "dir/datastream", ["D", "X"])
     assert len(reduced) == len(labelled_files) - d_count - x_count + 1
     assert "dir/datastream" in reduced
 
-    reduced = bringer.reduce_files(labelled_files, "dir/XCCDF", ["D", "X"])
+    reduced = analyzer.reduce_files(labelled_files, "dir/XCCDF", ["D", "X"])
     assert len(reduced) == len(labelled_files) - d_count - x_count + 1
     assert "dir/XCCDF" in reduced
 
     with pytest.raises(content_handling.ContentHandlingError, match="dir/datastream4"):
-        bringer.reduce_files(labelled_files, "dir/datastream4", ["D"])
+        analyzer.reduce_files(labelled_files, "dir/datastream4", ["D"])
 
-    reduced = bringer.reduce_files(labelled_files, "cpe", ["C"])
+    reduced = analyzer.reduce_files(labelled_files, "cpe", ["C"])
     assert reduced == labelled_files
 
 

--- a/tests/test_content_discovery.py
+++ b/tests/test_content_discovery.py
@@ -22,7 +22,7 @@ def labelled_files():
 
 
 def test_reduce(labelled_files):
-    bringer = tested_module.ContentBringer(None)
+    bringer = tested_module.ContentBringer()
 
     d_count = 0
     x_count = 0


### PR DESCRIPTION
#### Description:
This PR contains a series of small refactoring of the code responsible for content fetching, with focus on the `org_fedora_oscap.content_discovery.ContentBringer` class.

The main change is that the code performing analysis of the content has been moved away from `ContentBringer` to a new class `ContentAnalyzer`.

Moreover, code manipulating the members of the `PolicyData` class has been moved away from `ContentBringer` to the `PolicyData` class.

The outcome is that now the `ContentBringer` contains only code performing the download of the content and `ContentAnalyzer` contains only code performing the analysis of the already fetched content. These 2 classes are independent.

For more details, please read commit messages of all commits.

#### Rationale:
This change prepares the code for further refactoring with the goal to consolidate content fetching functionality. The separation of content fetching and content analysis functionality will allow us to focus on each of these 2 stages separately, with lower mutual collisions, in future PRs.

#### Review Hints:

cd testing_files/
python3 -m http.server

./create_update_image.sh install_addon_from_repo

./reanaconda.py updates ~/work/git/oscap-anaconda-addon/update.img
