### PR TITLE
Update anaconda imports

### DIFF
--- a/org_fedora_oscap/common.py
+++ b/org_fedora_oscap/common.py
@@ -45,7 +45,7 @@ from pyanaconda.core.constants import PAYLOAD_TYPE_DNF
 from pyanaconda.modules.common.constants.namespaces import ADDONS_NAMESPACE
 from pyanaconda.modules.common.constants.services import NETWORK, PAYLOADS
 from pyanaconda.modules.common.structures.packages import PackagesSelectionData
-from pyanaconda.threading import threadMgr, AnacondaThread
+from pyanaconda.core.threads import thread_manager, AnacondaThread
 
 from org_fedora_oscap import utils
 from org_fedora_oscap import cpioarchive

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -6,7 +6,7 @@ from glob import glob
 from typing import List
 
 from pyanaconda.core import constants
-from pyanaconda.threading import threadMgr
+from pyanaconda.core.threads import thread_manager
 from pykickstart.errors import KickstartValueError
 
 from org_fedora_oscap import data_fetch, utils
@@ -194,7 +194,7 @@ class ContentBringer:
     def _finish_actual_fetch(self, wait_for, fingerprint, report_callback, dest_filename):
         if wait_for:
             log.info(f"OSCAP Addon: Waiting for thread {wait_for}")
-            threadMgr.wait(wait_for)
+            thread_manager.wait(wait_for)
             log.info(f"OSCAP Addon: Finished waiting for thread {wait_for}")
         actually_fetched_content = wait_for is not None
 

--- a/org_fedora_oscap/data_fetch.py
+++ b/org_fedora_oscap/data_fetch.py
@@ -11,7 +11,7 @@ import pycurl
 
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core import constants
-from pyanaconda.threading import threadMgr, AnacondaThread
+from pyanaconda.core.threads import thread_manager, AnacondaThread
 from pyanaconda.modules.common.constants.services import NETWORK
 
 from org_fedora_oscap import common
@@ -90,7 +90,7 @@ def fetch_local_data(url, out_file):
                                        fatal=False)
 
     # register and run the thread
-    threadMgr.add(fetch_data_thread)
+    thread_manager.add(fetch_data_thread)
 
     return common.THREAD_FETCH_DATA
 
@@ -107,7 +107,7 @@ def wait_and_fetch_net_data(url, out_file, ca_certs_path=None):
     """
 
     # get thread that tries to establish a network connection
-    nm_conn_thread = threadMgr.get(constants.THREAD_WAIT_FOR_CONNECTING_NM)
+    nm_conn_thread = thread_manager.get(constants.THREAD_WAIT_FOR_CONNECTING_NM)
     if nm_conn_thread:
         # NM still connecting, wait for it to finish
         nm_conn_thread.join()
@@ -123,7 +123,7 @@ def wait_and_fetch_net_data(url, out_file, ca_certs_path=None):
                                        fatal=False)
 
     # register and run the thread
-    threadMgr.add(fetch_data_thread)
+    thread_manager.add(fetch_data_thread)
 
     return common.THREAD_FETCH_DATA
 

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -37,7 +37,7 @@ from org_fedora_oscap.structures import PolicyData
 
 from pyanaconda.modules.common.constants.services import USERS
 from pyanaconda.modules.common.util import is_module_available
-from pyanaconda.threading import threadMgr, AnacondaThread
+from pyanaconda.core.threads import thread_manager, AnacondaThread
 from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.communication import hubQ
 from pyanaconda.ui.gui.utils import async_action_wait, really_hide, really_show
@@ -410,9 +410,11 @@ class OSCAPSpoke(NormalSpoke):
                           _("Fetching content data"))
         # pylint: disable-msg=E1101
         hubQ.send_not_ready(self.__class__.__name__)
-        threadMgr.add(AnacondaThread(name="OSCAPguiWaitForDataFetchThread",
-                                     target=self._init_after_data_fetch,
-                                     args=(thread_name,)))
+        thread_manager.add(AnacondaThread(
+            name="OSCAPguiWaitForDataFetchThread",
+            target=self._init_after_data_fetch,
+            args=(thread_name,)
+        ))
 
     @set_ready
     def _init_after_data_fetch(self, wait_for):


### PR DESCRIPTION
#### Description:

Update imports after anaconda changes.

#### Rationale:

Old imports will stop working eventually.

#### Review Hints:

- Depends on https://github.com/rhinstaller/anaconda/pull/4643
- The PR above includes a compatibility module, so this can be merged later.
- To be manually tested.