### PR TITLE
Introduce policy data wrapper class

### DIFF
--- a/org_fedora_oscap/data_handling.py
+++ b/org_fedora_oscap/data_handling.py
@@ -1,0 +1,9 @@
+class DataHandler:
+    def __init__(self, policy_data) -> None:
+        self._policy_data = policy_data
+
+    def needs_fetch_content(self) -> bool:
+        return (
+            self._policy_data.content_url and
+            self._policy_data.content_type != "scap-security-guide"
+        )

--- a/org_fedora_oscap/data_handling.py
+++ b/org_fedora_oscap/data_handling.py
@@ -1,3 +1,6 @@
+from org_fedora_oscap import common
+
+
 class DataHandler:
     def __init__(self, policy_data) -> None:
         self._policy_data = policy_data
@@ -7,3 +10,31 @@ class DataHandler:
             self._policy_data.content_url and
             self._policy_data.content_type != "scap-security-guide"
         )
+
+    def use_system_content(self):
+        self._policy_data.clear_all()
+        self._policy_data.content_type = "scap-security-guide"
+        self._policy_data.content_path = common.get_ssg_path()
+
+    def use_downloaded_content(self, content):
+        preferred_content = content.get_preferred_content(
+            self._policy_data.content_path)
+
+        # We know that we have ended up with a datastream-like content,
+        # but if we can't convert an archive to a datastream.
+        # self._policy_data.content_type = "datastream"
+        content_type = self._policy_data.content_type
+        if content_type in ("archive", "rpm"):
+            self._policy_data.content_path = str(
+                preferred_content.relative_to(content.root))
+        else:
+            self._policy_data.content_path = str(preferred_content)
+
+        preferred_tailoring = content.get_preferred_tailoring(
+            self._policy_data.tailoring_path)
+        if content.tailoring:
+            if content_type in ("archive", "rpm"):
+                self._policy_data.tailoring_path = str(
+                    preferred_tailoring.relative_to(content.root))
+            else:
+                self._policy_data.tailoring_path = str(preferred_tailoring)

--- a/org_fedora_oscap/data_handling.py
+++ b/org_fedora_oscap/data_handling.py
@@ -5,7 +5,7 @@ class PolicyDataHandler:
     def __init__(self, policy_data):
         self._policy_data = policy_data
 
-    def needs_fetch_content(self):
+    def content_is_fetchable(self):
         return (
             self._policy_data.content_url and
             self._policy_data.content_type != "scap-security-guide"

--- a/org_fedora_oscap/data_handling.py
+++ b/org_fedora_oscap/data_handling.py
@@ -38,3 +38,12 @@ class DataHandler:
                     preferred_tailoring.relative_to(content.root))
             else:
                 self._policy_data.tailoring_path = str(preferred_tailoring)
+
+    def set_url(self, url):
+        self._policy_data.content_url = url
+        if url.endswith(".rpm"):
+            self._policy_data.content_type = "rpm"
+        elif any(url.endswith(arch_type) for arch_type in common.SUPPORTED_ARCHIVES):
+            self._policy_data.content_type = "archive"
+        else:
+            self._policy_data.content_type = "datastream"

--- a/org_fedora_oscap/data_handling.py
+++ b/org_fedora_oscap/data_handling.py
@@ -1,11 +1,11 @@
 from org_fedora_oscap import common
 
 
-class DataHandler:
-    def __init__(self, policy_data) -> None:
+class PolicyDataHandler:
+    def __init__(self, policy_data):
         self._policy_data = policy_data
 
-    def needs_fetch_content(self) -> bool:
+    def needs_fetch_content(self):
         return (
             self._policy_data.content_url and
             self._policy_data.content_type != "scap-security-guide"

--- a/org_fedora_oscap/data_handling.py
+++ b/org_fedora_oscap/data_handling.py
@@ -11,6 +11,12 @@ class PolicyDataHandler:
             self._policy_data.content_type != "scap-security-guide"
         )
 
+    def content_defined(self):
+        return (
+            self._policy_data.content_url or
+            self._policy_data.content_type == "scap-security-guide"
+        )
+
     def use_system_content(self):
         self._policy_data.clear_all()
         self._policy_data.content_type = "scap-security-guide"

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -33,6 +33,7 @@ from org_fedora_oscap import scap_content_handler
 from org_fedora_oscap import content_discovery
 from org_fedora_oscap import utils
 from org_fedora_oscap.constants import OSCAP
+from org_fedora_oscap.data_handling import DataHandler
 from org_fedora_oscap.structures import PolicyData
 
 from pyanaconda.modules.common.constants.services import USERS
@@ -240,6 +241,7 @@ class OSCAPSpoke(NormalSpoke):
 
         self._policy_data = PolicyData()
         self._load_policy_data()
+        self.data_handler = DataHandler(self._policy_data)
 
         # used for changing profiles
         self._rule_data = None
@@ -402,7 +404,7 @@ class OSCAPSpoke(NormalSpoke):
             self._fetching = True
 
         thread_name = None
-        if self._policy_data.content_url and self._policy_data.content_type != "scap-security-guide":
+        if self.data_handler.needs_fetch_content():
             log.info(f"OSCAP Addon: Actually fetching content from somewhere")
             thread_name = self.content_bringer.fetch_content(
                 self._policy_data.content_url,

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -271,11 +271,6 @@ class OSCAPSpoke(NormalSpoke):
         log.debug("OSCAP addon: Anaconda init_done signal triggered")
         self._anaconda_spokes_initialized.set()
 
-    @property
-    def _content_defined(self):
-        return self._policy_data.content_url \
-            or self._policy_data.content_type == "scap-security-guide"
-
     def initialize(self):
         """
         The initialize method that is called after the instance is created.
@@ -341,7 +336,7 @@ class OSCAPSpoke(NormalSpoke):
             self._policy_data.content_path = common.SSG_DIR + common.SSG_CONTENT
             self._save_policy_data()
 
-        if not self._content_defined:
+        if not self.data_handler.content_defined():
             # nothing more to be done now, the spoke is ready
             self._ready = True
 
@@ -929,7 +924,7 @@ class OSCAPSpoke(NormalSpoke):
 
     def _refresh_ui(self):
         """Refresh the UI elements."""
-        if not self._content_defined:
+        if not self.data_handler.content_defined():
             log.info("OSCAP Addon: Content not defined")
             # hide the control buttons
             really_hide(self._control_buttons)
@@ -1014,7 +1009,7 @@ class OSCAPSpoke(NormalSpoke):
 
         """
 
-        if not self._content_defined or not self._active_profile:
+        if not self.data_handler.content_defined() or not self._active_profile:
             # no errors for no content or no profile
             self._set_error(None)
 
@@ -1088,7 +1083,7 @@ class OSCAPSpoke(NormalSpoke):
             # not initialized
             return self._unitialized_status
 
-        if not self._content_defined:
+        if not self.data_handler.content_defined():
             return _("No content found")
 
         if not self._active_profile:

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -399,7 +399,7 @@ class OSCAPSpoke(NormalSpoke):
             self._fetching = True
 
         thread_name = None
-        if self.data_handler.needs_fetch_content():
+        if self.data_handler.content_is_fetchable():
             log.info(f"OSCAP Addon: Actually fetching content from somewhere")
             thread_name = self.content_bringer.fetch_content(
                 self._policy_data.content_url,

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -458,7 +458,7 @@ class OSCAPSpoke(NormalSpoke):
 
         try:
             if actually_fetched_content:
-                self._use_downloaded_content(content)
+                self.data_handler.use_downloaded_content(content)
 
             preinst_content_path = common.get_preinst_content_path(self._policy_data)
             preinst_tailoring_path = common.get_preinst_tailoring_path(self._policy_data)
@@ -1221,34 +1221,6 @@ class OSCAPSpoke(NormalSpoke):
         self._refresh_ui()
 
     def on_use_ssg_clicked(self, *args):
-        self._use_system_content()
+        self.data_handler.use_system_content()
         self._save_policy_data()
         self._fetch_data_and_initialize()
-
-    def _use_system_content(self):
-        self._policy_data.clear_all()
-        self._policy_data.content_type = "scap-security-guide"
-        self._policy_data.content_path = common.get_ssg_path()
-
-    def _use_downloaded_content(self, content):
-        preferred_content = content.get_preferred_content(
-            self._policy_data.content_path)
-
-        # We know that we have ended up with a datastream-like content,
-        # but if we can't convert an archive to a datastream.
-        # self._policy_data.content_type = "datastream"
-        content_type = self._policy_data.content_type
-        if content_type in ("archive", "rpm"):
-            self._policy_data.content_path = str(
-                preferred_content.relative_to(content.root))
-        else:
-            self._policy_data.content_path = str(preferred_content)
-
-        preferred_tailoring = content.get_preferred_tailoring(
-            self._policy_data.tailoring_path)
-        if content.tailoring:
-            if content_type in ("archive", "rpm"):
-                self._policy_data.tailoring_path = str(
-                    preferred_tailoring.relative_to(content.root))
-            else:
-                self._policy_data.tailoring_path = str(preferred_tailoring)

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -33,7 +33,7 @@ from org_fedora_oscap import scap_content_handler
 from org_fedora_oscap import content_discovery
 from org_fedora_oscap import utils
 from org_fedora_oscap.constants import OSCAP
-from org_fedora_oscap.data_handling import DataHandler
+from org_fedora_oscap.data_handling import PolicyDataHandler
 from org_fedora_oscap.structures import PolicyData
 
 from pyanaconda.modules.common.constants.services import USERS
@@ -241,7 +241,7 @@ class OSCAPSpoke(NormalSpoke):
 
         self._policy_data = PolicyData()
         self._load_policy_data()
-        self.data_handler = DataHandler(self._policy_data)
+        self.data_handler = PolicyDataHandler(self._policy_data)
 
         # used for changing profiles
         self._rule_data = None

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -1200,13 +1200,7 @@ class OSCAPSpoke(NormalSpoke):
 
         self._progress_label.set_text(_("Fetching content..."))
         self._progress_spinner.start()
-        self._policy_data.content_url = url
-        if url.endswith(".rpm"):
-            self._policy_data.content_type = "rpm"
-        elif any(url.endswith(arch_type) for arch_type in common.SUPPORTED_ARCHIVES):
-            self._policy_data.content_type = "archive"
-        else:
-            self._policy_data.content_type = "datastream"
+        self.data_handler.set_url(url)
 
         self._fetch_data_and_initialize()
 

--- a/org_fedora_oscap/service/installation.py
+++ b/org_fedora_oscap/service/installation.py
@@ -19,6 +19,7 @@ import logging
 import os
 import shutil
 import io
+from org_fedora_oscap.data_handling import PolicyDataHandler
 
 from pyanaconda.core import util
 from pyanaconda.modules.common.task import Task
@@ -74,6 +75,7 @@ class PrepareValidContent(Task):
         self._file_path = file_path
         self._content_path = content_path
         self.content_bringer = content_discovery.ContentBringer(_handle_error)
+        self.data_handler = PolicyDataHandler(self._policy_data)
 
     @property
     def name(self):
@@ -83,7 +85,8 @@ class PrepareValidContent(Task):
         """Run the task."""
         # Is the content available?
         fetching_thread_name = None
-        if not os.path.exists(self._content_path):
+        if (self.data_handler.content_is_fetchable()
+                and not os.path.exists(self._content_path)):
             # content not available/fetched yet
             fetching_thread_name = self.content_bringer.fetch_content(
                 self._policy_data.content_url,


### PR DESCRIPTION
#### Description:

Introduce a PolicyDataHandler class and move some items from the OSCAPScope class to this new class.

#### Rationale:
OSCAPScope is a class that handles GUI, but has too many other responsibilities, apart from GUI items there is many functional logic involved. The OSCAPScope often manipulates the PolicyData class, so it would be natural to move this code to the PolicyData class. However, this class is intended to work only as a data structure. We will not break this intention so we will create a new class PolicyDataHandler that manipulates the existing PolicyData class.

This separation also improves testability.

#### Review Hints:
all relates to GUI installation
./create_update_image.sh install_addon_from_repo
./reanaconda.py updates ~/work/git/oscap-anaconda-addon/update.img 
try to load content from a server, eg. provided by `python3 -m http.server`
