### PR TITLE
Make the Bringer better testable

### DIFF
--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -95,7 +95,7 @@ class ContentBringer:
         with self.activity_lock:
             if self.now_fetching_or_processing:
                 msg = _(
-                    f"Attempting to fetch '{self._valid_content_uri}, "
+                    f"Attempting to fetch '{self.content_uri}, "
                     "but the previous fetch is still in progress")
                 log.warn(f"OSCAP Addon: {msg}")
                 return
@@ -119,8 +119,8 @@ class ContentBringer:
         if is_network(scheme):
             try:
                 data_fetch.wait_for_network()
-            except common.OSCAPaddonNetworkError:
-                msg = _("Network connection needed to fetch data.")
+            except common.OSCAPaddonNetworkError as exc:
+                msg = _(f"Network connection needed to fetch data. {exc}")
                 raise common.OSCAPaddonNetworkError(msg)
 
         fetch_data_thread = AnacondaThread(
@@ -129,7 +129,6 @@ class ContentBringer:
             args=(self.content_uri, self.dest_file_name, ca_certs_path),
             fatal=False)
 
-        # register and run the thread
         threadMgr.add(fetch_data_thread)
 
         return fetching_thread_name

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -31,7 +31,6 @@ def paths_are_equivalent(p1, p2):
 
 
 def path_is_present_among_paths(path, paths):
-    absolute_path = os.path.abspath(path)
     for second_path in paths:
         if paths_are_equivalent(path, second_path):
             return True

--- a/org_fedora_oscap/data_fetch.py
+++ b/org_fedora_oscap/data_fetch.py
@@ -84,9 +84,9 @@ def wait_for_network(timeout=None):
 
     network_proxy = NETWORK.get_proxy()
     if not network_proxy.Connected:
-        msg = _("Unable to connect to the network.")
+        msg = _("Failed to connect.")
         if timeout is not None:
-            msg += " " + _(f"Waited for {timeout} seconds.")
+            msg += " " + _(f"Reached the timeout of {timeout} s.")
         raise common.OSCAPaddonNetworkError(msg)
 
 

--- a/org_fedora_oscap/data_fetch.py
+++ b/org_fedora_oscap/data_fetch.py
@@ -75,57 +75,19 @@ class FetchError(DataFetchError):
     pass
 
 
-def fetch_local_data(url, out_file):
-    """
-    Function that fetches data locally.
-
-    :see: org_fedora_oscap.data_fetch.fetch_data
-    :return: the name of the thread running fetch_data
-    :rtype: str
-
-    """
-    fetch_data_thread = AnacondaThread(name=common.THREAD_FETCH_DATA,
-                                       target=fetch_data,
-                                       args=(url, out_file, None),
-                                       fatal=False)
-
-    # register and run the thread
-    threadMgr.add(fetch_data_thread)
-
-    return common.THREAD_FETCH_DATA
-
-
-def wait_and_fetch_net_data(url, out_file, ca_certs_path=None):
-    """
-    Function that waits for network connection and starts a thread that fetches
-    data over network.
-
-    :see: org_fedora_oscap.data_fetch.fetch_data
-    :return: the name of the thread running fetch_data
-    :rtype: str
-
-    """
-
+def wait_for_network(timeout=None):
     # get thread that tries to establish a network connection
     nm_conn_thread = threadMgr.get(constants.THREAD_WAIT_FOR_CONNECTING_NM)
     if nm_conn_thread:
         # NM still connecting, wait for it to finish
-        nm_conn_thread.join()
+        nm_conn_thread.join(timeout)
 
     network_proxy = NETWORK.get_proxy()
     if not network_proxy.Connected:
-        raise common.OSCAPaddonNetworkError(_("Network connection needed to fetch data."))
-
-    log.info(f"Fetching data from {url}")
-    fetch_data_thread = AnacondaThread(name=common.THREAD_FETCH_DATA,
-                                       target=fetch_data,
-                                       args=(url, out_file, ca_certs_path),
-                                       fatal=False)
-
-    # register and run the thread
-    threadMgr.add(fetch_data_thread)
-
-    return common.THREAD_FETCH_DATA
+        msg = _("Unable to connect to the network.")
+        if timeout is not None:
+            msg += " " + _(f"Waited for {timeout} seconds.")
+        raise common.OSCAPaddonNetworkError(msg)
 
 
 def can_fetch_from(url):

--- a/tests/test_content_discovery.py
+++ b/tests/test_content_discovery.py
@@ -77,9 +77,9 @@ def test_path_presence_detection():
 
 
 class SlowBringer(tested_module.ContentBringer):
-    def fetch_operation(self, uri, out_file, cacerts=None):
+    def fetch_operation(self, out_file):
         time.sleep(1)
-        super().fetch_operation(uri, out_file, cacerts)
+        super().fetch_operation(out_file)
 
 
 def if_problem_raise_exception(exc):


### PR DESCRIPTION
#### Description:

This PR moves functionality formerly located in the data_fetch module to the Bringer, so one can use polymorphism to create great mocks by just subclassing.
Now, it is possible to test handling of threads and fetch methods separately, because Bringer just calls a method to fetch a URI, and then wraps the process in a thread.

#### Rationale:

- The PR decomposes and concentrates the existing functionality, making it easier to test.

#### Review Hints:

- Business as usual, tests pass, bringer still able to copy things, touched functions were not used by other parts of the addon.