### PR TITLE
Port #237 to rawhide branch

### DIFF
--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -93,11 +93,10 @@ class ContentBringer:
         self.content_uri = self._addon_data.content_url
         shutil.rmtree(self.CONTENT_DOWNLOAD_LOCATION, ignore_errors=True)
         self.CONTENT_DOWNLOAD_LOCATION.mkdir(parents=True, exist_ok=True)
-        fetching_thread_name = self._fetch_files(
-            self.CONTENT_DOWNLOAD_LOCATION, ca_certs_path, what_if_fail)
+        fetching_thread_name = self._fetch_files(ca_certs_path, what_if_fail)
         return fetching_thread_name
 
-    def _fetch_files(self, destdir, ca_certs_path, what_if_fail):
+    def _fetch_files(self, ca_certs_path, what_if_fail):
         with self.activity_lock:
             if self.now_fetching_or_processing:
                 msg = "OSCAP Addon: Strange, it seems that we are already fetching something."
@@ -107,7 +106,7 @@ class ContentBringer:
 
         fetching_thread_name = None
         try:
-            fetching_thread_name = self._start_actual_fetch(destdir, ca_certs_path)
+            fetching_thread_name = self._start_actual_fetch(ca_certs_path)
         except Exception as exc:
             with self.activity_lock:
                 self.now_fetching_or_processing = False
@@ -130,10 +129,10 @@ class ContentBringer:
         dest = destdir / basename
         return dest
 
-    def _start_actual_fetch(self, destdir, ca_certs_path):
+    def _start_actual_fetch(self, ca_certs_path):
         fetching_thread_name = None
 
-        dest = ContentBringer.__get_dest_file_name(self.content_uri, destdir)
+        dest = ContentBringer.__get_dest_file_name(self.content_uri, self.CONTENT_DOWNLOAD_LOCATION)
 
         scheme = self.content_uri.split("://")[0]
         if is_network(scheme):

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -254,7 +254,8 @@ class ContentBringer:
         # self._addon_data.content_type = "datastream"
         self._addon_data.content_path = str(preferred_content.relative_to(content.root))
 
-        preferred_tailoring = self.get_preferred_tailoring(content)
+        tailoring_path = self._addon_data.tailoring_path
+        preferred_tailoring = self.get_preferred_tailoring(tailoring_path, content)
         if content.tailoring:
             self._addon_data.tailoring_path = str(preferred_tailoring.relative_to(content.root))
 
@@ -265,8 +266,7 @@ class ContentBringer:
             preferred_content = content.select_main_usable_content()
         return preferred_content
 
-    def get_preferred_tailoring(self, content):
-        tailoring_path = self._addon_data.tailoring_path
+    def get_preferred_tailoring(self, tailoring_path, content):
         if tailoring_path:
             if tailoring_path != str(content.tailoring.relative_to(content.root)):
                 msg = f"Expected a tailoring {tailoring_path}, but it couldn't be found"

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -51,6 +51,7 @@ class ContentBringer:
     def __init__(self, addon_data):
         self._content_uri = ""
         self.fetched_content = ""
+        self.dest_file_name = ""
 
         self.activity_lock = threading.Lock()
         self.now_fetching_or_processing = False
@@ -79,7 +80,16 @@ class ContentBringer:
                 f"Invalid supplied content URL '{uri}', "
                 "use the 'scheme://path' form.")
             raise KickstartValueError(msg)
+        path = scheme_and_maybe_path[1]
+        if "/" not in path:
+            msg = f"Missing the path component of the '{uri}' URL"
+            raise KickstartValueError(msg)
+        basename = path.rsplit("/", 1)[1]
+        if not basename:
+            msg = f"Unable to deduce basename from the '{uri}' URL"
+            raise KickstartValueError(msg)
         self._content_uri = uri
+        self.dest_file_name = self.CONTENT_DOWNLOAD_LOCATION / basename
 
     def fetch_content(self, what_if_fail, ca_certs_path=""):
         """
@@ -114,20 +124,6 @@ class ContentBringer:
 
         # We are not finished yet with the fetch
         return fetching_thread_name
-
-    @property
-    def dest_file_name(self):
-        path = self.content_uri.split("://")[1]
-        if "/" not in path:
-            msg = f"Missing the path component of the '{self.content_uri}' URL"
-            raise KickstartValueError(msg)
-        basename = path.rsplit("/", 1)[1]
-        if not basename:
-            msg = f"Unable to deduce basename from the '{self.content_uri}' URL"
-            raise KickstartValueError(msg)
-
-        dest = self.CONTENT_DOWNLOAD_LOCATION / basename
-        return dest
 
     def _start_actual_fetch(self, ca_certs_path):
         fetching_thread_name = None

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -162,7 +162,7 @@ class ContentBringer:
             self._finish_actual_fetch(fetching_thread_name)
             if fingerprint and dest_filename:
                 self._verify_fingerprint(fingerprint)
-            content = self._analyze_fetched_content(
+            content = ContentBringer.__analyze_fetched_content(
                 fetching_thread_name, fingerprint, dest_filename,
                 expected_path, expected_tailoring, expected_cpe_path)
         except Exception as exc:
@@ -198,13 +198,14 @@ class ContentBringer:
             raise content_handling.ContentCheckError(msg)
         log.info(f"Integrity check passed using {hash_obj.name} hash")
 
-    def _analyze_fetched_content(
-                self, wait_for, fingerprint, dest_filename, expected_path,
+    @staticmethod
+    def __analyze_fetched_content(
+                wait_for, fingerprint, dest_filename, expected_path,
                 expected_tailoring, expected_cpe_path):
         actually_fetched_content = wait_for is not None
         fpaths = ContentBringer.__gather_available_files(actually_fetched_content, dest_filename)
 
-        structured_content = ObtainedContent(self.CONTENT_DOWNLOAD_LOCATION)
+        structured_content = ObtainedContent(ContentBringer.CONTENT_DOWNLOAD_LOCATION)
         content_type = ContentBringer.__get_content_type(str(dest_filename))
         log.info(f"OSCAP Addon: started to look at the content")
         if content_type in ("archive", "rpm"):

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -247,7 +247,7 @@ class ContentBringer:
         return fpaths
 
     def use_downloaded_content(self, content):
-        preferred_content = self.get_preferred_content(content)
+        preferred_content = self.get_preferred_content(self._addon_data.content_path, content)
 
         # We know that we have ended up with a datastream-like content,
         # but if we can't convert an archive to a datastream.
@@ -259,9 +259,9 @@ class ContentBringer:
         if content.tailoring:
             self._addon_data.tailoring_path = str(preferred_tailoring.relative_to(content.root))
 
-    def get_preferred_content(self, content):
-        if self._addon_data.content_path:
-            preferred_content = content.find_expected_usable_content(self._addon_data.content_path)
+    def get_preferred_content(self, content_path, content):
+        if content_path:
+            preferred_content = content.find_expected_usable_content(content_path)
         else:
             preferred_content = content.select_main_usable_content()
         return preferred_content

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -246,19 +246,6 @@ class ContentBringer:
                 raise common.OSCAPaddonError("Unsupported content type")
         return fpaths
 
-    def use_downloaded_content(self, content):
-        preferred_content = content.get_preferred_content(self._addon_data.content_path)
-
-        # We know that we have ended up with a datastream-like content,
-        # but if we can't convert an archive to a datastream.
-        # self._addon_data.content_type = "datastream"
-        self._addon_data.content_path = str(preferred_content.relative_to(content.root))
-
-        tailoring_path = self._addon_data.tailoring_path
-        preferred_tailoring = content.get_preferred_tailoring(tailoring_path)
-        if content.tailoring:
-            self._addon_data.tailoring_path = str(preferred_tailoring.relative_to(content.root))
-
 
 class ObtainedContent:
     """

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -258,11 +258,6 @@ class ContentBringer:
         if content.tailoring:
             self._addon_data.tailoring_path = str(preferred_tailoring.relative_to(content.root))
 
-    def use_system_content(self, content=None):
-        self._addon_data.clear_all()
-        self._addon_data.content_type = "scap-security-guide"
-        self._addon_data.content_path = common.get_ssg_path()
-
     def get_preferred_content(self, content):
         if self._addon_data.content_path:
             preferred_content = content.find_expected_usable_content(self._addon_data.content_path)

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -42,7 +42,7 @@ class ContentBringer:
     CONTENT_DOWNLOAD_LOCATION = pathlib.Path(common.INSTALLATION_CONTENT_DIR)
 
     def __init__(self, what_if_fail):
-        self._content_uri = ""
+        self._valid_content_uri = ""
         self.dest_file_name = ""
 
         self.activity_lock = threading.Lock()
@@ -53,7 +53,7 @@ class ContentBringer:
 
     @property
     def content_uri(self):
-        return self._content_uri
+        return self._valid_content_uri
 
     @content_uri.setter
     def content_uri(self, uri):
@@ -71,7 +71,7 @@ class ContentBringer:
         if not basename:
             msg = f"Unable to deduce basename from the '{uri}' URL"
             raise KickstartValueError(msg)
-        self._content_uri = uri
+        self._valid_content_uri = uri
         self.dest_file_name = self.CONTENT_DOWNLOAD_LOCATION / basename
 
     def fetch_content(self, content_uri, ca_certs_path=""):

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -41,12 +41,13 @@ def path_is_present_among_paths(path, paths):
 class ContentBringer:
     CONTENT_DOWNLOAD_LOCATION = pathlib.Path(common.INSTALLATION_CONTENT_DIR)
 
-    def __init__(self):
+    def __init__(self, what_if_fail):
         self._content_uri = ""
         self.dest_file_name = ""
 
         self.activity_lock = threading.Lock()
         self.now_fetching_or_processing = False
+        self.what_if_fail = what_if_fail
 
         self.CONTENT_DOWNLOAD_LOCATION.mkdir(parents=True, exist_ok=True)
 
@@ -73,25 +74,23 @@ class ContentBringer:
         self._content_uri = uri
         self.dest_file_name = self.CONTENT_DOWNLOAD_LOCATION / basename
 
-    def fetch_content(self, content_uri, what_if_fail, ca_certs_path=""):
+    def fetch_content(self, content_uri, ca_certs_path=""):
         """
         Initiate fetch of the content into an appropriate directory
 
         Args:
-            what_if_fail: Callback accepting exception as an argument that
-                should handle them in the calling layer.
             ca_certs_path: Path to the HTTPS certificate file
         """
         try:
             self.content_uri = content_uri
         except Exception as exc:
-            what_if_fail(exc)
+            self.what_if_fail(exc)
         shutil.rmtree(self.CONTENT_DOWNLOAD_LOCATION, ignore_errors=True)
         self.CONTENT_DOWNLOAD_LOCATION.mkdir(parents=True, exist_ok=True)
-        fetching_thread_name = self._fetch_files(ca_certs_path, what_if_fail)
+        fetching_thread_name = self._fetch_files(ca_certs_path)
         return fetching_thread_name
 
-    def _fetch_files(self, ca_certs_path, what_if_fail):
+    def _fetch_files(self, ca_certs_path):
         with self.activity_lock:
             if self.now_fetching_or_processing:
                 msg = "OSCAP Addon: Strange, it seems that we are already fetching something."
@@ -105,7 +104,7 @@ class ContentBringer:
         except Exception as exc:
             with self.activity_lock:
                 self.now_fetching_or_processing = False
-            what_if_fail(exc)
+            self.what_if_fail(exc)
 
         # We are not finished yet with the fetch
         return fetching_thread_name
@@ -127,14 +126,13 @@ class ContentBringer:
             )
         return fetching_thread_name
 
-    def finish_content_fetch(
-            self, fetching_thread_name, fingerprint, what_if_fail):
+    def finish_content_fetch(self, fetching_thread_name, fingerprint):
         try:
             self._finish_actual_fetch(fetching_thread_name)
             if fingerprint:
                 self._verify_fingerprint(fingerprint)
         except Exception as exc:
-            what_if_fail(exc)
+            self.what_if_fail(exc)
         finally:
             with self.activity_lock:
                 self.now_fetching_or_processing = False

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -142,7 +142,7 @@ class ContentBringer:
             )
         return fetching_thread_name
 
-    def finish_content_fetch(self, fetching_thread_name, fingerprint, report_callback, dest_filename,
+    def finish_content_fetch(self, fetching_thread_name, fingerprint, dest_filename,
                              what_if_fail):
         """
         Finish any ongoing fetch and analyze what has been fetched.
@@ -164,7 +164,7 @@ class ContentBringer:
             Instance of ObtainedContent if everything went well, or None.
         """
         try:
-            content = self._finish_actual_fetch(fetching_thread_name, fingerprint, report_callback, dest_filename)
+            content = self._finish_actual_fetch(fetching_thread_name, fingerprint, dest_filename)
         except Exception as exc:
             what_if_fail(exc)
             content = None
@@ -192,7 +192,7 @@ class ContentBringer:
             raise content_handling.ContentCheckError(msg)
         log.info(f"Integrity check passed using {hash_obj.name} hash")
 
-    def _finish_actual_fetch(self, wait_for, fingerprint, report_callback, dest_filename):
+    def _finish_actual_fetch(self, wait_for, fingerprint, dest_filename):
         if wait_for:
             log.info(f"OSCAP Addon: Waiting for thread {wait_for}")
             threadMgr.wait(wait_for)

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -50,7 +50,6 @@ class ContentBringer:
 
     def __init__(self, addon_data):
         self._content_uri = ""
-        self.fetched_content = ""
         self.dest_file_name = ""
 
         self.activity_lock = threading.Lock()

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -114,10 +114,9 @@ class ContentBringer:
         # We are not finished yet with the fetch
         return fetching_thread_name
 
-    def _start_actual_fetch(self, scheme, path, destdir, ca_certs_path):
-        fetching_thread_name = None
-        url = scheme + "://" + path
-
+    @staticmethod
+    def __get_dest_file_name(url, destdir):
+        path = url.split("://")[1]
         if "/" not in path:
             msg = f"Missing the path component of the '{url}' URL"
             raise KickstartValueError(msg)
@@ -127,6 +126,13 @@ class ContentBringer:
             raise KickstartValueError(msg)
 
         dest = destdir / basename
+        return dest
+
+    def _start_actual_fetch(self, scheme, path, destdir, ca_certs_path):
+        fetching_thread_name = None
+        url = scheme + "://" + path
+
+        dest = ContentBringer.__get_dest_file_name(url, destdir)
 
         if is_network(scheme):
             fetching_thread_name = data_fetch.wait_and_fetch_net_data(

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -51,7 +51,8 @@ class ContentBringer:
 
         self.CONTENT_DOWNLOAD_LOCATION.mkdir(parents=True, exist_ok=True)
 
-    def get_content_type(self, url):
+    @staticmethod
+    def __get_content_type(url):
         if url.endswith(".rpm"):
             return "rpm"
         elif any(url.endswith(arch_type) for arch_type in common.SUPPORTED_ARCHIVES):
@@ -205,7 +206,7 @@ class ContentBringer:
         fpaths = self._gather_available_files(actually_fetched_content, dest_filename)
 
         structured_content = ObtainedContent(self.CONTENT_DOWNLOAD_LOCATION)
-        content_type = self.get_content_type(str(dest_filename))
+        content_type = ContentBringer.__get_content_type(str(dest_filename))
         log.info(f"OSCAP Addon: started to look at the content")
         if content_type in ("archive", "rpm"):
             structured_content.add_content_archive(dest_filename)
@@ -232,7 +233,7 @@ class ContentBringer:
         else:
             dest_filename = pathlib.Path(dest_filename)
             # RPM is an archive at this phase
-            content_type = self.get_content_type(str(dest_filename))
+            content_type = ContentBringer.__get_content_type(str(dest_filename))
             if content_type in ("archive", "rpm"):
                 try:
                     fpaths = common.extract_data(

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -79,6 +79,7 @@ class ContentBringer:
         Initiate fetch of the content into an appropriate directory
 
         Args:
+            content_uri: URI location of the content to be fetched
             ca_certs_path: Path to the HTTPS certificate file
         """
         try:

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -128,11 +128,10 @@ class ContentBringer:
         return fetching_thread_name
 
     def finish_content_fetch(
-            self, fetching_thread_name, fingerprint, dest_filename,
-            what_if_fail):
+            self, fetching_thread_name, fingerprint, what_if_fail):
         try:
             self._finish_actual_fetch(fetching_thread_name)
-            if fingerprint and dest_filename:
+            if fingerprint:
                 self._verify_fingerprint(fingerprint)
         except Exception as exc:
             what_if_fail(exc)

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -90,7 +90,7 @@ class ContentBringer:
         self._content_uri = uri
         self.dest_file_name = self.CONTENT_DOWNLOAD_LOCATION / basename
 
-    def fetch_content(self, what_if_fail, ca_certs_path=""):
+    def fetch_content(self, content_uri, what_if_fail, ca_certs_path=""):
         """
         Initiate fetch of the content into an appropriate directory
 
@@ -99,7 +99,10 @@ class ContentBringer:
                 should handle them in the calling layer.
             ca_certs_path: Path to the HTTPS certificate file
         """
-        self.content_uri = self._addon_data.content_url
+        try:
+            self.content_uri = content_uri
+        except Exception as exc:
+            what_if_fail(exc)
         shutil.rmtree(self.CONTENT_DOWNLOAD_LOCATION, ignore_errors=True)
         self.CONTENT_DOWNLOAD_LOCATION.mkdir(parents=True, exist_ok=True)
         fetching_thread_name = self._fetch_files(ca_certs_path, what_if_fail)

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -164,7 +164,8 @@ class ContentBringer:
             Instance of ObtainedContent if everything went well, or None.
         """
         try:
-            content = self._finish_actual_fetch(fetching_thread_name, fingerprint, dest_filename)
+            self._finish_actual_fetch(fetching_thread_name)
+            content = self._analyze_fetched_content(fetching_thread_name, fingerprint, dest_filename)
         except Exception as exc:
             what_if_fail(exc)
             content = None
@@ -192,11 +193,13 @@ class ContentBringer:
             raise content_handling.ContentCheckError(msg)
         log.info(f"Integrity check passed using {hash_obj.name} hash")
 
-    def _finish_actual_fetch(self, wait_for, fingerprint, dest_filename):
+    def _finish_actual_fetch(self, wait_for):
         if wait_for:
             log.info(f"OSCAP Addon: Waiting for thread {wait_for}")
             threadMgr.wait(wait_for)
             log.info(f"OSCAP Addon: Finished waiting for thread {wait_for}")
+
+    def _analyze_fetched_content(self, wait_for, fingerprint, dest_filename):
         actually_fetched_content = wait_for is not None
 
         if fingerprint and dest_filename:

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -165,6 +165,8 @@ class ContentBringer:
         """
         try:
             self._finish_actual_fetch(fetching_thread_name)
+            if fingerprint and dest_filename:
+                self._verify_fingerprint(dest_filename, fingerprint)
             content = self._analyze_fetched_content(fetching_thread_name, fingerprint, dest_filename)
         except Exception as exc:
             what_if_fail(exc)
@@ -201,10 +203,6 @@ class ContentBringer:
 
     def _analyze_fetched_content(self, wait_for, fingerprint, dest_filename):
         actually_fetched_content = wait_for is not None
-
-        if fingerprint and dest_filename:
-            self._verify_fingerprint(dest_filename, fingerprint)
-
         fpaths = self._gather_available_files(actually_fetched_content, dest_filename)
 
         structured_content = ObtainedContent(self.CONTENT_DOWNLOAD_LOCATION)

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -115,36 +115,34 @@ class ContentBringer:
         # We are not finished yet with the fetch
         return fetching_thread_name
 
-    @staticmethod
-    def __get_dest_file_name(url, destdir):
-        path = url.split("://")[1]
+    @property
+    def dest_file_name(self):
+        path = self.content_uri.split("://")[1]
         if "/" not in path:
-            msg = f"Missing the path component of the '{url}' URL"
+            msg = f"Missing the path component of the '{self.content_uri}' URL"
             raise KickstartValueError(msg)
         basename = path.rsplit("/", 1)[1]
         if not basename:
-            msg = f"Unable to deduce basename from the '{url}' URL"
+            msg = f"Unable to deduce basename from the '{self.content_uri}' URL"
             raise KickstartValueError(msg)
 
-        dest = destdir / basename
+        dest = self.CONTENT_DOWNLOAD_LOCATION / basename
         return dest
 
     def _start_actual_fetch(self, ca_certs_path):
         fetching_thread_name = None
 
-        dest = ContentBringer.__get_dest_file_name(self.content_uri, self.CONTENT_DOWNLOAD_LOCATION)
-
         scheme = self.content_uri.split("://")[0]
         if is_network(scheme):
             fetching_thread_name = data_fetch.wait_and_fetch_net_data(
                 self.content_uri,
-                dest,
+                self.dest_file_name,
                 ca_certs_path
             )
         else:  # invalid schemes are handled down the road
             fetching_thread_name = data_fetch.fetch_local_data(
                 self.content_uri,
-                dest,
+                self.dest_file_name,
             )
         return fetching_thread_name
 

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -166,7 +166,7 @@ class ContentBringer:
         try:
             self._finish_actual_fetch(fetching_thread_name)
             if fingerprint and dest_filename:
-                self._verify_fingerprint(dest_filename, fingerprint)
+                self._verify_fingerprint(fingerprint)
             content = self._analyze_fetched_content(fetching_thread_name, fingerprint, dest_filename)
         except Exception as exc:
             what_if_fail(exc)
@@ -177,18 +177,18 @@ class ContentBringer:
 
         return content
 
-    def _verify_fingerprint(self, dest_filename, fingerprint=""):
+    def _verify_fingerprint(self, fingerprint=""):
         if not fingerprint:
             log.info("OSCAP Addon: No fingerprint provided, skipping integrity check")
             return
 
         hash_obj = utils.get_hashing_algorithm(fingerprint)
-        digest = utils.get_file_fingerprint(dest_filename,
+        digest = utils.get_file_fingerprint(self.dest_file_name,
                                             hash_obj)
         if digest != fingerprint:
             log.error(
                 "OSCAP Addon: "
-                f"File {dest_filename} failed integrity check - assumed a "
+                f"File {self.dest_file_name} failed integrity check - assumed a "
                 f"{hash_obj.name} hash and '{fingerprint}', got '{digest}'"
             )
             msg = _(f"OSCAP Addon: Integrity check of the content failed - {hash_obj.name} hash didn't match")

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -255,7 +255,7 @@ class ContentBringer:
         self._addon_data.content_path = str(preferred_content.relative_to(content.root))
 
         tailoring_path = self._addon_data.tailoring_path
-        preferred_tailoring = self.get_preferred_tailoring(tailoring_path, content)
+        preferred_tailoring = content.get_preferred_tailoring(tailoring_path)
         if content.tailoring:
             self._addon_data.tailoring_path = str(preferred_tailoring.relative_to(content.root))
 
@@ -265,13 +265,6 @@ class ContentBringer:
         else:
             preferred_content = content.select_main_usable_content()
         return preferred_content
-
-    def get_preferred_tailoring(self, tailoring_path, content):
-        if tailoring_path:
-            if tailoring_path != str(content.tailoring.relative_to(content.root)):
-                msg = f"Expected a tailoring {tailoring_path}, but it couldn't be found"
-                raise content_handling.ContentHandlingError(msg)
-        return content.tailoring
 
 
 class ObtainedContent:
@@ -370,3 +363,10 @@ class ObtainedContent:
                 "Couldn't find a valid datastream or a valid XCCDF-OVAL file tuple "
                 "among the available content")
             raise content_handling.ContentHandlingError(msg)
+
+    def get_preferred_tailoring(self, tailoring_path):
+        if tailoring_path:
+            if tailoring_path != str(self.tailoring.relative_to(self.root)):
+                msg = f"Expected a tailoring {tailoring_path}, but it couldn't be found"
+                raise content_handling.ContentHandlingError(msg)
+        return self.tailoring

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -207,9 +207,16 @@ class ContentBringer:
         if content_type in ("archive", "rpm"):
             structured_content.add_content_archive(dest_filename)
 
-        labelled_files = content_handling.identify_files(fpaths)
-        for fname, label in labelled_files.items():
-            structured_content.add_file(fname, label)
+        labelled_filenames = content_handling.identify_files(fpaths)
+        expected_path = common.get_preinst_content_path(self._addon_data)
+        expected_tailoring = common.get_preinst_tailoring_path(self._addon_data)
+        expected_cpe_path = self._addon_data.cpe_path
+        labelled_filenames = self.filter_discovered_content(
+            labelled_filenames, expected_path, expected_tailoring,
+            expected_cpe_path)
+
+        for fname, label in labelled_filenames.items():
+            structured_content.add_file(str(fname), label)
 
         if fingerprint and dest_filename:
             structured_content.record_verification(dest_filename)

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -42,7 +42,7 @@ class ContentBringer:
     CONTENT_DOWNLOAD_LOCATION = pathlib.Path(common.INSTALLATION_CONTENT_DIR)
     DEFAULT_SSG_DATA_STREAM_PATH = f"{common.SSG_DIR}/{common.SSG_CONTENT}"
 
-    def __init__(self, addon_data):
+    def __init__(self):
         self._content_uri = ""
         self.dest_file_name = ""
 
@@ -50,8 +50,6 @@ class ContentBringer:
         self.now_fetching_or_processing = False
 
         self.CONTENT_DOWNLOAD_LOCATION.mkdir(parents=True, exist_ok=True)
-
-        self._addon_data = addon_data
 
     def get_content_type(self, url):
         if url.endswith(".rpm"):

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -139,7 +139,7 @@ class ContentBringer:
         return fetching_thread_name
 
     def finish_content_fetch(self, fetching_thread_name, fingerprint, dest_filename,
-                             what_if_fail):
+                             what_if_fail, expected_path, expected_tailoring, expected_cpe_path):
         """
         Finish any ongoing fetch and analyze what has been fetched.
 
@@ -163,9 +163,6 @@ class ContentBringer:
             self._finish_actual_fetch(fetching_thread_name)
             if fingerprint and dest_filename:
                 self._verify_fingerprint(fingerprint)
-            expected_path = common.get_preinst_content_path(self._addon_data)
-            expected_tailoring = common.get_preinst_tailoring_path(self._addon_data)
-            expected_cpe_path = self._addon_data.cpe_path
             content = self._analyze_fetched_content(
                 fetching_thread_name, fingerprint, dest_filename,
                 expected_path, expected_tailoring, expected_cpe_path)

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -247,7 +247,7 @@ class ContentBringer:
         return fpaths
 
     def use_downloaded_content(self, content):
-        preferred_content = self.get_preferred_content(self._addon_data.content_path, content)
+        preferred_content = content.get_preferred_content(self._addon_data.content_path)
 
         # We know that we have ended up with a datastream-like content,
         # but if we can't convert an archive to a datastream.
@@ -258,13 +258,6 @@ class ContentBringer:
         preferred_tailoring = content.get_preferred_tailoring(tailoring_path)
         if content.tailoring:
             self._addon_data.tailoring_path = str(preferred_tailoring.relative_to(content.root))
-
-    def get_preferred_content(self, content_path, content):
-        if content_path:
-            preferred_content = content.find_expected_usable_content(content_path)
-        else:
-            preferred_content = content.select_main_usable_content()
-        return preferred_content
 
 
 class ObtainedContent:
@@ -370,3 +363,10 @@ class ObtainedContent:
                 msg = f"Expected a tailoring {tailoring_path}, but it couldn't be found"
                 raise content_handling.ContentHandlingError(msg)
         return self.tailoring
+
+    def get_preferred_content(self, content_path):
+        if content_path:
+            preferred_content = self.find_expected_usable_content(content_path)
+        else:
+            preferred_content = self.select_main_usable_content()
+        return preferred_content

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -202,7 +202,7 @@ class ContentBringer:
                 self, wait_for, fingerprint, dest_filename, expected_path,
                 expected_tailoring, expected_cpe_path):
         actually_fetched_content = wait_for is not None
-        fpaths = self._gather_available_files(actually_fetched_content, dest_filename)
+        fpaths = ContentBringer.__gather_available_files(actually_fetched_content, dest_filename)
 
         structured_content = ObtainedContent(self.CONTENT_DOWNLOAD_LOCATION)
         content_type = ContentBringer.__get_content_type(str(dest_filename))
@@ -221,13 +221,14 @@ class ContentBringer:
         log.info(f"OSCAP Addon: finished looking at the content")
         return structured_content
 
-    def _gather_available_files(self, actually_fetched_content, dest_filename):
+    @staticmethod
+    def __gather_available_files(actually_fetched_content, dest_filename):
         fpaths = []
         if not actually_fetched_content:
             if not dest_filename:  # using scap-security-guide
-                fpaths = [self.DEFAULT_SSG_DATA_STREAM_PATH]
+                fpaths = [ContentBringer.DEFAULT_SSG_DATA_STREAM_PATH]
             else:  # Using downloaded XCCDF/OVAL/DS/tailoring
-                fpaths = pathlib.Path(self.CONTENT_DOWNLOAD_LOCATION).rglob("*")
+                fpaths = pathlib.Path(ContentBringer.CONTENT_DOWNLOAD_LOCATION).rglob("*")
                 fpaths = [str(p) for p in fpaths if p.is_file()]
         else:
             dest_filename = pathlib.Path(dest_filename)

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -127,8 +127,9 @@ class ContentBringer:
             )
         return fetching_thread_name
 
-    def finish_content_fetch(self, fetching_thread_name, fingerprint, dest_filename,
-                             what_if_fail, expected_path, expected_tailoring, expected_cpe_path):
+    def finish_content_fetch(
+            self, fetching_thread_name, fingerprint, dest_filename,
+            what_if_fail):
         try:
             self._finish_actual_fetch(fetching_thread_name)
             if fingerprint and dest_filename:

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -198,7 +198,6 @@ class ContentBringer:
             raise content_handling.ContentCheckError(msg)
         log.info(f"Integrity check passed using {hash_obj.name} hash")
 
-
     def _analyze_fetched_content(
                 self, wait_for, fingerprint, dest_filename, expected_path,
                 expected_tailoring, expected_cpe_path):

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -94,7 +94,8 @@ class ContentBringer:
     def _fetch_files(self, ca_certs_path):
         with self.activity_lock:
             if self.now_fetching_or_processing:
-                msg = "OSCAP Addon: Strange, it seems that we are already fetching something."
+                msg = "OSCAP Addon: Strange, it seems that we are already " \
+                    "fetching something."
                 log.warn(msg)
                 return
             self.now_fetching_or_processing = True
@@ -146,7 +147,9 @@ class ContentBringer:
 
     def _verify_fingerprint(self, fingerprint=""):
         if not fingerprint:
-            log.info("OSCAP Addon: No fingerprint provided, skipping integrity check")
+            log.info(
+                "OSCAP Addon: No fingerprint provided, skipping integrity "
+                "check")
             return
 
         hash_obj = utils.get_hashing_algorithm(fingerprint)
@@ -155,10 +158,12 @@ class ContentBringer:
         if digest != fingerprint:
             log.error(
                 "OSCAP Addon: "
-                f"File {self.dest_file_name} failed integrity check - assumed a "
-                f"{hash_obj.name} hash and '{fingerprint}', got '{digest}'"
+                f"File {self.dest_file_name} failed integrity check - assumed "
+                f"a {hash_obj.name} hash and '{fingerprint}', got '{digest}'"
             )
-            msg = _(f"OSCAP Addon: Integrity check of the content failed - {hash_obj.name} hash didn't match")
+            msg = _(
+                f"OSCAP Addon: Integrity check of the content failed - "
+                f"{hash_obj.name} hash didn't match")
             raise content_handling.ContentCheckError(msg)
         log.info(f"Integrity check passed using {hash_obj.name} hash")
 
@@ -171,7 +176,9 @@ class ContentAnalyzer:
     def __get_content_type(url):
         if url.endswith(".rpm"):
             return "rpm"
-        elif any(url.endswith(arch_type) for arch_type in common.SUPPORTED_ARCHIVES):
+        elif any(
+                url.endswith(arch_type)
+                for arch_type in common.SUPPORTED_ARCHIVES):
             return "archive"
         else:
             return "file"
@@ -194,9 +201,11 @@ class ContentAnalyzer:
                 wait_for, fingerprint, dest_filename, expected_path,
                 expected_tailoring, expected_cpe_path):
         actually_fetched_content = wait_for is not None
-        fpaths = ContentAnalyzer.__gather_available_files(actually_fetched_content, dest_filename)
+        fpaths = ContentAnalyzer.__gather_available_files(
+            actually_fetched_content, dest_filename)
 
-        structured_content = ObtainedContent(ContentAnalyzer.CONTENT_DOWNLOAD_LOCATION)
+        structured_content = ObtainedContent(
+            ContentAnalyzer.CONTENT_DOWNLOAD_LOCATION)
         content_type = ContentAnalyzer.__get_content_type(str(dest_filename))
         log.info(f"OSCAP Addon: started to look at the content")
         if content_type in ("archive", "rpm"):
@@ -220,12 +229,14 @@ class ContentAnalyzer:
             if not dest_filename:  # using scap-security-guide
                 fpaths = [ContentAnalyzer.DEFAULT_SSG_DATA_STREAM_PATH]
             else:  # Using downloaded XCCDF/OVAL/DS/tailoring
-                fpaths = pathlib.Path(ContentAnalyzer.CONTENT_DOWNLOAD_LOCATION).rglob("*")
+                fpaths = pathlib.Path(
+                    ContentAnalyzer.CONTENT_DOWNLOAD_LOCATION).rglob("*")
                 fpaths = [str(p) for p in fpaths if p.is_file()]
         else:
             dest_filename = pathlib.Path(dest_filename)
             # RPM is an archive at this phase
-            content_type = ContentAnalyzer.__get_content_type(str(dest_filename))
+            content_type = ContentAnalyzer.__get_content_type(
+                str(dest_filename))
             if content_type in ("archive", "rpm"):
                 try:
                     fpaths = common.extract_data(
@@ -233,7 +244,9 @@ class ContentAnalyzer:
                         str(dest_filename.parent)
                     )
                 except common.ExtractionError as err:
-                    msg = f"Failed to extract the '{dest_filename}' archive: {str(err)}"
+                    msg = (
+                        f"Failed to extract the '{dest_filename}' "
+                        f"archive: {str(err)}")
                     log.error("OSCAP Addon: " + msg)
                     raise err
 

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -1,5 +1,6 @@
 import threading
 import logging
+import os
 import pathlib
 import shutil
 from glob import glob
@@ -12,7 +13,7 @@ from pykickstart.errors import KickstartValueError
 from org_fedora_oscap import data_fetch, utils
 from org_fedora_oscap import common
 from org_fedora_oscap import content_handling
-from org_fedora_oscap import rule_handling
+from org_fedora_oscap.content_handling import CONTENT_TYPES
 
 from org_fedora_oscap.common import _
 
@@ -25,23 +26,16 @@ def is_network(scheme):
         for net_prefix in data_fetch.NET_URL_PREFIXES)
 
 
-def clear_all(data):
-    data.content_type = ""
-    data.content_url = ""
-    data.datastream_id = ""
-    data.xccdf_id = ""
-    data.profile_id = ""
-    data.content_path = ""
-    data.cpe_path = ""
-    data.tailoring_path = ""
+def paths_are_equivalent(p1, p2):
+    return os.path.abspath(p1) == os.path.abspath(p2)
 
-    data.fingerprint = ""
 
-    data.certificates = ""
-
-    # internal values
-    data.rule_data = rule_handling.RuleData()
-    data.dry_run = False
+def path_is_present_among_paths(path, paths):
+    absolute_path = os.path.abspath(path)
+    for second_path in paths:
+        if paths_are_equivalent(path, second_path):
+            return True
+    return False
 
 
 class ContentBringer:
@@ -265,7 +259,7 @@ class ContentBringer:
             self._addon_data.tailoring_path = str(preferred_tailoring.relative_to(content.root))
 
     def use_system_content(self, content=None):
-        clear_all(self._addon_data)
+        self._addon_data.clear_all()
         self._addon_data.content_type = "scap-security-guide"
         self._addon_data.content_path = common.get_ssg_path()
 

--- a/org_fedora_oscap/content_discovery.py
+++ b/org_fedora_oscap/content_discovery.py
@@ -179,6 +179,12 @@ class ContentBringer:
 
         return content
 
+    def _finish_actual_fetch(self, wait_for):
+        if wait_for:
+            log.info(f"OSCAP Addon: Waiting for thread {wait_for}")
+            threadMgr.wait(wait_for)
+            log.info(f"OSCAP Addon: Finished waiting for thread {wait_for}")
+
     def _verify_fingerprint(self, fingerprint=""):
         if not fingerprint:
             log.info("OSCAP Addon: No fingerprint provided, skipping integrity check")
@@ -196,12 +202,6 @@ class ContentBringer:
             msg = _(f"OSCAP Addon: Integrity check of the content failed - {hash_obj.name} hash didn't match")
             raise content_handling.ContentCheckError(msg)
         log.info(f"Integrity check passed using {hash_obj.name} hash")
-
-    def _finish_actual_fetch(self, wait_for):
-        if wait_for:
-            log.info(f"OSCAP Addon: Waiting for thread {wait_for}")
-            threadMgr.wait(wait_for)
-            log.info(f"OSCAP Addon: Finished waiting for thread {wait_for}")
 
     def _analyze_fetched_content(self, wait_for, fingerprint, dest_filename):
         actually_fetched_content = wait_for is not None

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -263,7 +263,7 @@ class OSCAPSpoke(NormalSpoke):
         self._anaconda_spokes_initialized = threading.Event()
         self.initialization_controller.init_done.connect(self._all_anaconda_spokes_initialized)
 
-        self.content_bringer = content_discovery.ContentBringer(self._policy_data)
+        self.content_bringer = content_discovery.ContentBringer()
         self._content_handler = None
 
     def _all_anaconda_spokes_initialized(self):

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -441,8 +441,7 @@ class OSCAPSpoke(NormalSpoke):
 
         self.content_bringer.finish_content_fetch(
             wait_for, self._policy_data.fingerprint, content_path,
-            self._handle_error, expected_path, expected_tailoring,
-            expected_cpe_path)
+            self._handle_error)
         content = content_discovery.ContentAnalyzer.analyze(
             wait_for, self._policy_data.fingerprint, content_path,
             self._handle_error, expected_path, expected_tailoring,

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -435,7 +435,7 @@ class OSCAPSpoke(NormalSpoke):
             content_path = common.get_raw_preinst_content_path(self._policy_data)
 
         content = self.content_bringer.finish_content_fetch(
-            wait_for, self._policy_data.fingerprint, update_progress_label,
+            wait_for, self._policy_data.fingerprint,
             content_path, self._handle_error)
         if not content:
             with self._fetch_flag_lock:

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -435,9 +435,14 @@ class OSCAPSpoke(NormalSpoke):
         if actually_fetched_content:
             content_path = common.get_raw_preinst_content_path(self._policy_data)
 
+        expected_path = common.get_preinst_content_path(self._policy_data)
+        expected_tailoring = common.get_preinst_tailoring_path(self._policy_data)
+        expected_cpe_path = self._policy_data.cpe_path
+
         content = self.content_bringer.finish_content_fetch(
-            wait_for, self._policy_data.fingerprint,
-            content_path, self._handle_error)
+            wait_for, self._policy_data.fingerprint, content_path,
+            self._handle_error, expected_path, expected_tailoring,
+            expected_cpe_path)
         if not content:
             with self._fetch_flag_lock:
                 self._fetching = False

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -426,9 +426,6 @@ class OSCAPSpoke(NormalSpoke):
         :type wait_for: str or None
 
         """
-        def update_progress_label(msg):
-            fire_gtk_action(self._progress_label.set_text(msg))
-
         content_path = None
         actually_fetched_content = wait_for is not None
 

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -864,7 +864,7 @@ class OSCAPSpoke(NormalSpoke):
 
     @async_action_wait
     def _wrong_content(self, msg):
-        content_discovery.clear_all(self._policy_data)
+        self._policy_data.clear_all()
         really_hide(self._progress_spinner)
         self._fetch_button.set_sensitive(True)
         self._content_url_entry.set_sensitive(True)
@@ -1207,7 +1207,7 @@ class OSCAPSpoke(NormalSpoke):
 
     def on_change_content_clicked(self, *args):
         self._unselect_profile(self._active_profile)
-        content_discovery.clear_all(self._policy_data)
+        self._policy_data.clear_all()
         self._refresh_ui()
 
     def on_use_ssg_clicked(self, *args):

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -432,7 +432,7 @@ class OSCAPSpoke(NormalSpoke):
         if actually_fetched_content:
             content_path = common.get_raw_preinst_content_path(self._policy_data)
             self.content_bringer.finish_content_fetch(
-                wait_for, self._policy_data.fingerprint, content_path,
+                wait_for, self._policy_data.fingerprint,
                 self._handle_error)
 
         expected_path = common.get_preinst_content_path(self._policy_data)

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -263,7 +263,7 @@ class OSCAPSpoke(NormalSpoke):
         self._anaconda_spokes_initialized = threading.Event()
         self.initialization_controller.init_done.connect(self._all_anaconda_spokes_initialized)
 
-        self.content_bringer = content_discovery.ContentBringer()
+        self.content_bringer = content_discovery.ContentBringer(self._handle_error)
         self._content_handler = None
 
     def _all_anaconda_spokes_initialized(self):
@@ -404,7 +404,7 @@ class OSCAPSpoke(NormalSpoke):
             log.info(f"OSCAP Addon: Actually fetching content from somewhere")
             thread_name = self.content_bringer.fetch_content(
                 self._policy_data.content_url,
-                self._handle_error, self._policy_data.certificates)
+                self._policy_data.certificates)
 
         # pylint: disable-msg=E1101
         hubQ.send_message(self.__class__.__name__,
@@ -432,8 +432,7 @@ class OSCAPSpoke(NormalSpoke):
         if actually_fetched_content:
             content_path = common.get_raw_preinst_content_path(self._policy_data)
             self.content_bringer.finish_content_fetch(
-                wait_for, self._policy_data.fingerprint,
-                self._handle_error)
+                wait_for, self._policy_data.fingerprint)
 
         expected_path = common.get_preinst_content_path(self._policy_data)
         expected_tailoring = common.get_preinst_tailoring_path(self._policy_data)

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -439,7 +439,11 @@ class OSCAPSpoke(NormalSpoke):
         expected_tailoring = common.get_preinst_tailoring_path(self._policy_data)
         expected_cpe_path = self._policy_data.cpe_path
 
-        content = self.content_bringer.finish_content_fetch(
+        self.content_bringer.finish_content_fetch(
+            wait_for, self._policy_data.fingerprint, content_path,
+            self._handle_error, expected_path, expected_tailoring,
+            expected_cpe_path)
+        content = content_discovery.ContentAnalyzer.analyze(
             wait_for, self._policy_data.fingerprint, content_path,
             self._handle_error, expected_path, expected_tailoring,
             expected_cpe_path)

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -450,7 +450,7 @@ class OSCAPSpoke(NormalSpoke):
 
         try:
             if actually_fetched_content:
-                self.content_bringer.use_downloaded_content(content)
+                self._policy_data.use_downloaded_content(content)
 
             preinst_content_path = common.get_preinst_content_path(self._policy_data)
             preinst_tailoring_path = common.get_preinst_tailoring_path(self._policy_data)

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -434,14 +434,14 @@ class OSCAPSpoke(NormalSpoke):
 
         if actually_fetched_content:
             content_path = common.get_raw_preinst_content_path(self._policy_data)
+            self.content_bringer.finish_content_fetch(
+                wait_for, self._policy_data.fingerprint, content_path,
+                self._handle_error)
 
         expected_path = common.get_preinst_content_path(self._policy_data)
         expected_tailoring = common.get_preinst_tailoring_path(self._policy_data)
         expected_cpe_path = self._policy_data.cpe_path
 
-        self.content_bringer.finish_content_fetch(
-            wait_for, self._policy_data.fingerprint, content_path,
-            self._handle_error)
         content = content_discovery.ContentAnalyzer.analyze(
             wait_for, self._policy_data.fingerprint, content_path,
             self._handle_error, expected_path, expected_tailoring,

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -1211,6 +1211,6 @@ class OSCAPSpoke(NormalSpoke):
         self._refresh_ui()
 
     def on_use_ssg_clicked(self, *args):
-        self.content_bringer.use_system_content()
+        self._policy_data.use_system_content()
         self._save_policy_data()
         self._fetch_data_and_initialize()

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -454,7 +454,7 @@ class OSCAPSpoke(NormalSpoke):
 
         try:
             if actually_fetched_content:
-                self._policy_data.use_downloaded_content(content)
+                self._use_downloaded_content(content)
 
             preinst_content_path = common.get_preinst_content_path(self._policy_data)
             preinst_tailoring_path = common.get_preinst_tailoring_path(self._policy_data)
@@ -1215,6 +1215,34 @@ class OSCAPSpoke(NormalSpoke):
         self._refresh_ui()
 
     def on_use_ssg_clicked(self, *args):
-        self._policy_data.use_system_content()
+        self._use_system_content()
         self._save_policy_data()
         self._fetch_data_and_initialize()
+
+    def _use_system_content(self):
+        self._policy_data.clear_all()
+        self._policy_data.content_type = "scap-security-guide"
+        self._policy_data.content_path = common.get_ssg_path()
+
+    def _use_downloaded_content(self, content):
+        preferred_content = content.get_preferred_content(
+            self._policy_data.content_path)
+
+        # We know that we have ended up with a datastream-like content,
+        # but if we can't convert an archive to a datastream.
+        # self._policy_data.content_type = "datastream"
+        content_type = self._policy_data.content_type
+        if content_type in ("archive", "rpm"):
+            self._policy_data.content_path = str(
+                preferred_content.relative_to(content.root))
+        else:
+            self._policy_data.content_path = str(preferred_content)
+
+        preferred_tailoring = content.get_preferred_tailoring(
+            self._policy_data.tailoring_path)
+        if content.tailoring:
+            if content_type in ("archive", "rpm"):
+                self._policy_data.tailoring_path = str(
+                    preferred_tailoring.relative_to(content.root))
+            else:
+                self._policy_data.tailoring_path = str(preferred_tailoring)

--- a/org_fedora_oscap/gui/spokes/oscap.py
+++ b/org_fedora_oscap/gui/spokes/oscap.py
@@ -403,6 +403,7 @@ class OSCAPSpoke(NormalSpoke):
         if self._policy_data.content_url and self._policy_data.content_type != "scap-security-guide":
             log.info(f"OSCAP Addon: Actually fetching content from somewhere")
             thread_name = self.content_bringer.fetch_content(
+                self._policy_data.content_url,
                 self._handle_error, self._policy_data.certificates)
 
         # pylint: disable-msg=E1101

--- a/org_fedora_oscap/service/installation.py
+++ b/org_fedora_oscap/service/installation.py
@@ -88,7 +88,7 @@ class PrepareValidContent(Task):
 
         content = self.content_bringer.finish_content_fetch(
             fetching_thread_name, self._policy_data.fingerprint,
-            lambda msg: log.info("OSCAP Addon: " + msg), content_dest, _handle_error)
+            content_dest, _handle_error)
 
         if not content:
             # this shouldn't happen because error handling is supposed to

--- a/org_fedora_oscap/service/installation.py
+++ b/org_fedora_oscap/service/installation.py
@@ -67,7 +67,7 @@ class PrepareValidContent(Task):
         self._policy_data = policy_data
         self._file_path = file_path
         self._content_path = content_path
-        self.content_bringer = content_discovery.ContentBringer()
+        self.content_bringer = content_discovery.ContentBringer(_handle_error)
 
     @property
     def name(self):
@@ -81,7 +81,7 @@ class PrepareValidContent(Task):
             # content not available/fetched yet
             fetching_thread_name = self.content_bringer.fetch_content(
                 self._policy_data.content_url,
-                _handle_error, self._policy_data.certificates)
+                self._policy_data.certificates)
 
         content_dest = None
         fingerprint = None
@@ -94,7 +94,7 @@ class PrepareValidContent(Task):
         expected_cpe_path = self._policy_data.cpe_path
         if fetching_thread_name is not None:
             self.content_bringer.finish_content_fetch(
-                fetching_thread_name, fingerprint, _handle_error)
+                fetching_thread_name, fingerprint)
         content = content_discovery.ContentAnalyzer.analyze(
             fetching_thread_name, self._policy_data.fingerprint,
             content_dest, _handle_error, expected_path, expected_tailoring,

--- a/org_fedora_oscap/service/installation.py
+++ b/org_fedora_oscap/service/installation.py
@@ -104,7 +104,7 @@ class PrepareValidContent(Task):
 
         try:
             # just check that preferred content exists
-            _ = self.content_bringer.get_preferred_content(self._policy_data.content_path, content)
+            _ = content.get_preferred_content(self._policy_data.content_path)
         except Exception as exc:
             terminate(str(exc))
 

--- a/org_fedora_oscap/service/installation.py
+++ b/org_fedora_oscap/service/installation.py
@@ -104,7 +104,7 @@ class PrepareValidContent(Task):
 
         try:
             # just check that preferred content exists
-            _ = self.content_bringer.get_preferred_content(content)
+            _ = self.content_bringer.get_preferred_content(self._policy_data.content_path, content)
         except Exception as exc:
             terminate(str(exc))
 

--- a/org_fedora_oscap/service/installation.py
+++ b/org_fedora_oscap/service/installation.py
@@ -84,16 +84,17 @@ class PrepareValidContent(Task):
                 _handle_error, self._policy_data.certificates)
 
         content_dest = None
+        fingerprint = None
         if self._policy_data.content_type != "scap-security-guide":
             content_dest = self._file_path
+            fingerprint = self._policy_data.fingerprint
 
         expected_path = common.get_preinst_content_path(self._policy_data)
         expected_tailoring = common.get_preinst_tailoring_path(self._policy_data)
         expected_cpe_path = self._policy_data.cpe_path
         if fetching_thread_name is not None:
             self.content_bringer.finish_content_fetch(
-                fetching_thread_name, self._policy_data.fingerprint,
-                content_dest, _handle_error)
+                fetching_thread_name, fingerprint, _handle_error)
         content = content_discovery.ContentAnalyzer.analyze(
             fetching_thread_name, self._policy_data.fingerprint,
             content_dest, _handle_error, expected_path, expected_tailoring,

--- a/org_fedora_oscap/service/installation.py
+++ b/org_fedora_oscap/service/installation.py
@@ -90,9 +90,10 @@ class PrepareValidContent(Task):
         expected_path = common.get_preinst_content_path(self._policy_data)
         expected_tailoring = common.get_preinst_tailoring_path(self._policy_data)
         expected_cpe_path = self._policy_data.cpe_path
-        self.content_bringer.finish_content_fetch(
-            fetching_thread_name, self._policy_data.fingerprint,
-            content_dest, _handle_error)
+        if fetching_thread_name is not None:
+            self.content_bringer.finish_content_fetch(
+                fetching_thread_name, self._policy_data.fingerprint,
+                content_dest, _handle_error)
         content = content_discovery.ContentAnalyzer.analyze(
             fetching_thread_name, self._policy_data.fingerprint,
             content_dest, _handle_error, expected_path, expected_tailoring,

--- a/org_fedora_oscap/service/installation.py
+++ b/org_fedora_oscap/service/installation.py
@@ -92,8 +92,7 @@ class PrepareValidContent(Task):
         expected_cpe_path = self._policy_data.cpe_path
         self.content_bringer.finish_content_fetch(
             fetching_thread_name, self._policy_data.fingerprint,
-            content_dest, _handle_error, expected_path, expected_tailoring,
-            expected_cpe_path)
+            content_dest, _handle_error)
         content = content_discovery.ContentAnalyzer.analyze(
             fetching_thread_name, self._policy_data.fingerprint,
             content_dest, _handle_error, expected_path, expected_tailoring,

--- a/org_fedora_oscap/service/installation.py
+++ b/org_fedora_oscap/service/installation.py
@@ -87,9 +87,13 @@ class PrepareValidContent(Task):
         if self._policy_data.content_type != "scap-security-guide":
             content_dest = self._file_path
 
+        expected_path = common.get_preinst_content_path(self._policy_data)
+        expected_tailoring = common.get_preinst_tailoring_path(self._policy_data)
+        expected_cpe_path = self._policy_data.cpe_path
         content = self.content_bringer.finish_content_fetch(
             fetching_thread_name, self._policy_data.fingerprint,
-            content_dest, _handle_error)
+            content_dest, _handle_error, expected_path, expected_tailoring,
+            expected_cpe_path)
 
         if not content:
             # this shouldn't happen because error handling is supposed to

--- a/org_fedora_oscap/service/installation.py
+++ b/org_fedora_oscap/service/installation.py
@@ -90,7 +90,11 @@ class PrepareValidContent(Task):
         expected_path = common.get_preinst_content_path(self._policy_data)
         expected_tailoring = common.get_preinst_tailoring_path(self._policy_data)
         expected_cpe_path = self._policy_data.cpe_path
-        content = self.content_bringer.finish_content_fetch(
+        self.content_bringer.finish_content_fetch(
+            fetching_thread_name, self._policy_data.fingerprint,
+            content_dest, _handle_error, expected_path, expected_tailoring,
+            expected_cpe_path)
+        content = content_discovery.ContentAnalyzer.analyze(
             fetching_thread_name, self._policy_data.fingerprint,
             content_dest, _handle_error, expected_path, expected_tailoring,
             expected_cpe_path)

--- a/org_fedora_oscap/service/installation.py
+++ b/org_fedora_oscap/service/installation.py
@@ -67,7 +67,7 @@ class PrepareValidContent(Task):
         self._policy_data = policy_data
         self._file_path = file_path
         self._content_path = content_path
-        self.content_bringer = content_discovery.ContentBringer(policy_data)
+        self.content_bringer = content_discovery.ContentBringer()
 
     @property
     def name(self):

--- a/org_fedora_oscap/service/installation.py
+++ b/org_fedora_oscap/service/installation.py
@@ -80,6 +80,7 @@ class PrepareValidContent(Task):
         if not os.path.exists(self._content_path):
             # content not available/fetched yet
             fetching_thread_name = self.content_bringer.fetch_content(
+                self._policy_data.content_url,
                 _handle_error, self._policy_data.certificates)
 
         content_dest = None

--- a/org_fedora_oscap/structures.py
+++ b/org_fedora_oscap/structures.py
@@ -218,27 +218,3 @@ class PolicyData(DBusData):
         self.tailoring_path = ""
         self.fingerprint = ""
         self.certificates = ""
-
-    def use_system_content(self):
-        self.clear_all()
-        self.content_type = "scap-security-guide"
-        self.content_path = common.get_ssg_path()
-
-    def use_downloaded_content(self, content):
-        preferred_content = content.get_preferred_content(self.content_path)
-
-        # We know that we have ended up with a datastream-like content,
-        # but if we can't convert an archive to a datastream.
-        # self.content_type = "datastream"
-        content_type = self.content_type
-        if content_type in ("archive", "rpm"):
-            self.content_path = str(preferred_content.relative_to(content.root))
-        else:
-            self.content_path = str(preferred_content)
-
-        preferred_tailoring = content.get_preferred_tailoring(self.tailoring_path)
-        if content.tailoring:
-            if content_type in ("archive", "rpm"):
-                self.tailoring_path = str(preferred_tailoring.relative_to(content.root))
-            else:
-                self.tailoring_path = str(preferred_tailoring)

--- a/org_fedora_oscap/structures.py
+++ b/org_fedora_oscap/structures.py
@@ -18,6 +18,8 @@
 from dasbus.structure import DBusData
 from dasbus.typing import *  # pylint: disable=wildcard-import
 
+from org_fedora_oscap import rule_handling
+
 __all__ = ["PolicyData"]
 
 
@@ -204,3 +206,21 @@ class PolicyData(DBusData):
     @remediate.setter
     def remediate(self, value: Str):
         self._remediate = value
+
+    def clear_all(self):
+        self.content_type = ""
+        self.content_url = ""
+        self.datastream_id = ""
+        self.xccdf_id = ""
+        self.profile_id = ""
+        self.content_path = ""
+        self.cpe_path = ""
+        self.tailoring_path = ""
+
+        self.fingerprint = ""
+
+        self.certificates = ""
+
+        # internal values
+        self.rule_data = rule_handling.RuleData()
+        self.dry_run = False

--- a/org_fedora_oscap/structures.py
+++ b/org_fedora_oscap/structures.py
@@ -223,3 +223,22 @@ class PolicyData(DBusData):
         self.clear_all()
         self.content_type = "scap-security-guide"
         self.content_path = common.get_ssg_path()
+
+    def use_downloaded_content(self, content):
+        preferred_content = content.get_preferred_content(self.content_path)
+
+        # We know that we have ended up with a datastream-like content,
+        # but if we can't convert an archive to a datastream.
+        # self.content_type = "datastream"
+        content_type = self.content_type
+        if content_type in ("archive", "rpm"):
+            self.content_path = str(preferred_content.relative_to(content.root))
+        else:
+            self.content_path = str(preferred_content)
+
+        preferred_tailoring = content.get_preferred_tailoring(self.tailoring_path)
+        if content.tailoring:
+            if content_type in ("archive", "rpm"):
+                self.tailoring_path = str(preferred_tailoring.relative_to(content.root))
+            else:
+                self.tailoring_path = str(preferred_tailoring)

--- a/org_fedora_oscap/structures.py
+++ b/org_fedora_oscap/structures.py
@@ -18,8 +18,6 @@
 from dasbus.structure import DBusData
 from dasbus.typing import *  # pylint: disable=wildcard-import
 
-from org_fedora_oscap import rule_handling
-
 __all__ = ["PolicyData"]
 
 
@@ -216,11 +214,5 @@ class PolicyData(DBusData):
         self.content_path = ""
         self.cpe_path = ""
         self.tailoring_path = ""
-
         self.fingerprint = ""
-
         self.certificates = ""
-
-        # internal values
-        self.rule_data = rule_handling.RuleData()
-        self.dry_run = False

--- a/org_fedora_oscap/structures.py
+++ b/org_fedora_oscap/structures.py
@@ -18,6 +18,8 @@
 from dasbus.structure import DBusData
 from dasbus.typing import *  # pylint: disable=wildcard-import
 
+from org_fedora_oscap import common
+
 __all__ = ["PolicyData"]
 
 
@@ -216,3 +218,8 @@ class PolicyData(DBusData):
         self.tailoring_path = ""
         self.fingerprint = ""
         self.certificates = ""
+
+    def use_system_content(self):
+        self.clear_all()
+        self.content_type = "scap-security-guide"
+        self.content_path = common.get_ssg_path()


### PR DESCRIPTION
This ports https://github.com/OpenSCAP/oscap-anaconda-addon/pull/237 to `rawhide` branch.

I'm unable to say if it works or not. How can I test this? The steps in the Developer guide suggests using `reanaconda`, but `reanaconda prime` fails with a traceback when I try to pass a Fedora rawhide URL installation tree.