### PR TITLE
Remove obsolete mapping of packages-groups

### DIFF
--- a/org_fedora_oscap/rule_handling.py
+++ b/org_fedora_oscap/rule_handling.py
@@ -59,12 +59,6 @@ ESSENTIAL_PACKAGES = {
         "env": ["graphical-server-environment", "workstation-product-environment"],
         "groups": ["workstation-product-environment"],
     },
-    "tftp": {
-        "groups": ["network-server"],
-    },
-    "abrt": {
-        "groups": ["debugging"],
-    },
     "gssproxy": {
         "groups": ["file-server"],
     },


### PR DESCRIPTION
#### Description:

The mapping is a pain point in the addon - the related code is basically a cache of information that primarily exists in package/group metadata.

#### Rationale:

The `sftp` package is not part of the group any more, and `abrt` is not part of anything, because it doesn't exist.

- Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2172264

#### Review Hints:

Run e.g. `dnf group info network-server | grep ftp` on a RHEL9 system, or explore the package-group mapping by other means.