### PR TITLE
Make tar extraction safer on RHEL9

### DIFF
--- a/org_fedora_oscap/common.py
+++ b/org_fedora_oscap/common.py
@@ -392,7 +392,7 @@ def extract_data(archive, out_dir, ensure_has_files=None):
                 raise ExtractionError(msg)
 
         utils.ensure_dir_exists(out_dir)
-        zfile.extractall(path=out_dir)
+        zfile.extractall(path=out_dir, filter="data")
         result = [utils.join_paths(out_dir, info.filename) for info in zfile.filelist]
         zfile.close()
     elif archive.endswith(".tar"):
@@ -450,7 +450,7 @@ def _extract_tarball(archive, out_dir, ensure_has_files, alg):
             raise ExtractionError(msg)
 
     utils.ensure_dir_exists(out_dir)
-    tfile.extractall(path=out_dir)
+    tfile.extractall(path=out_dir, filter="data")
     result = [utils.join_paths(out_dir, member.path) for member in tfile.getmembers()]
     tfile.close()
 


### PR DESCRIPTION
See also https://bugzilla.redhat.com/show_bug.cgi?id=2218875

According to the referenced BZ, RHEL 9.3+ should contain means that allow safer tarfile extraction
Review Hints:

Test an install that uses a tar file as content container

#### Review hint

Kickstart installation snippet could look like this:

```
    content-url = http://10.0.2.2:8000/content.tar
    content-type = archive
    content-path = ssg-rhel9-ds.xml
```